### PR TITLE
Fix:Unnecessary Page Reload When Clicking on C2SI Logo

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.html
+++ b/webiu-ui/src/app/components/navbar/navbar.component.html
@@ -1,13 +1,8 @@
 <div class="navbar">
-  <a href="/" class="logo-link">
-    <img
-      src="../../../assets/c2silogo-dark_no_bg.png"
-      alt="C2SI Logo"
-      class="logo"
-    />
-  </a>
-
-  <div [ngClass]="{ navbar__menu: true, open: isMenuOpen }" id="navbarMenu">
+  <a [routerLink]="['/']" class="logo-link" (click)="preventReload($event)">
+    <img src="../../../assets/c2silogo-dark_no_bg.png" alt="C2SI Logo" class="logo" />
+  </a>  
+<div [ngClass]="{ navbar__menu: true, open: isMenuOpen }" id="navbarMenu">
     <div class="navbar__menu__items" routerLink="/">
       <img src="../../../assets/home.svg" alt="Home Icon" />
       <p>Home</p>

--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -68,7 +68,15 @@ export class NavbarComponent implements OnInit {
     
     window.location.href = 'http://localhost:6000/auth/github';
   }
-   // Close login options if clicked outside
+  // Prevent page reload and navigate to homepage if not already there
+  preventReload(event: Event): void {
+    if (this.router.url === '/') {
+      event.preventDefault();
+    } else {
+      this.router.navigate(['/']);
+    }
+  }
+  // Close login options if clicked outside
    @HostListener('document:click', ['$event'])
    onClickOutside(event: MouseEvent): void {
      const loginOptionsElement = document.querySelector('.login-options');


### PR DESCRIPTION
## Description
The changes ensure that when the C2SI logo is clicked, the page does not reload if the user is already on the homepage. This enhances the user experience by preventing unnecessary reloads and redirects users to the homepage only when they are not already on it.

## Related Issue #132 
Fixes issue where clicking the C2SI logo reloads the page even when on the homepage.

## Motivation and Context
This change improves the user experience by eliminating unnecessary reloads on the homepage. It ensures that clicking the logo behaves consistently, redirecting the user to the homepage only when needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests have passed and it does not give any unexpected error for the same.

