### PR TITLE
Fix: Sort 'Filter by Repository' dropdown list alphabetically

### DIFF
--- a/webiu-ui/src/app/page/contributors/contributors.component.html
+++ b/webiu-ui/src/app/page/contributors/contributors.component.html
@@ -17,10 +17,8 @@
     <div class="filter-section">
       <span>Filter by repository</span>
       <select class="repository-select" (change)="onRepoChange($event)">
-        <option value="">Codelabz</option>
-        @for (repo of allRepos; track $index) {
-        <option [value]="repo">{{ repo }}</option>
-        }
+        <option value="">Select a Repository</option>
+        <option *ngFor="let repo of allRepos" [value]="repo">{{ repo }}</option>
       </select>
     </div>
     <div class="contributors-card-container loading-spinner">

--- a/webiu-ui/src/app/page/contributors/contributors.component.ts
+++ b/webiu-ui/src/app/page/contributors/contributors.component.ts
@@ -68,7 +68,8 @@ export class ContributorsComponent implements OnInit {
 
 
   getUniqueRepos(): string[] {
-    return Array.from(new Set(this.profiles.flatMap((profile) => profile.repos)));
+    return Array.from(new Set(this.profiles.flatMap((profile) => profile.repos)))
+      .sort();  // Sorting repositories alphabetically
   }
 
   onRepoChange(event: Event) {


### PR DESCRIPTION
## Description
This PR ensures that the repository names in the "Filter by Repository" dropdown on the Contributors page are displayed in ascending alphabetical order. Previously, the list was unordered, making it difficult for users to locate a specific repository efficiently.

## Related Issue #134 
Fixes issue where the repository dropdown list was not sorted alphabetically.

## Motivation and Context
This change improves usability by making it easier for users to find a repository in the dropdown.
Ensures a consistent and logical order for better user experience.
Removes any predefined repository (like "Codelabz") from the top, ensuring all repositories are sorted alphabetically.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests have passed and it does not give any unexpected error for the same.

