### PR TITLE
Fix: prevent Card component crash when data is undefined

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -17,7 +17,7 @@ export const Card = ({ header, data, card, services, buttonLink, buttonText }) =
         </div> : null}
         <Container>
            <Row>
-           {card && data.map((data, index) => (
+           {card && data && data.map((data, index) => (
                <Col lg={4} key={index} className="card-col">
                    <div className="card-div">
                        <img src={data.image} className="card-img" alt="logo" />
@@ -36,7 +36,7 @@ export const Card = ({ header, data, card, services, buttonLink, buttonText }) =
                    </div>
                </Col>
            ))}
-           {services && data.map((data, index) => (
+           {services && data && data.map((data, index) => (
                <Col lg={4} key={index} className="services-col">
                    <div className="services-div">
                        <img src={data.image} className="services-img" alt="logo" />


### PR DESCRIPTION
## Description
This PR adds a safety check to prevent runtime errors in the Card component when the `data` prop is undefined.

## Related Issue
N/A

## Motivation and Context
The Card component assumes that the `data` prop is always provided. When it is missing or undefined, the component throws a runtime error due to calling `.map()` on an undefined value.
This change improves robustness without altering existing behavior.

## Screenshots (In case of UI changes)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project.
- [x] All new and existing tests have passed and it does not give any unexpected error for the same.
