### PR TITLE
Fix: restore placeholder contributors when API is not configured

### DIFF
--- a/webiu-ui/src/app/page/contributors/contributors.component.ts
+++ b/webiu-ui/src/app/page/contributors/contributors.component.ts
@@ -89,14 +89,22 @@ export class ContributorsComponent implements OnInit {
       )
       .subscribe({
         next: (res) => {
-          this.contributors = res || [];
-          this.fetchFollowerData();
+          if (!res || res.length === 0) {
+    console.warn('Empty API response, using placeholder contributors');
+    this.contributors = contributors;
+} else {
+  this.contributors = res;
+}
+this.fetchFollowerData();
+
           console.log('fetched contributors');
         },
         error: () => {
-          console.error('Error fetching contributors');
-          this.handleProfileResponse([]);
-        },
+    console.error('Error fetching contributors, using placeholder data');
+    this.contributors = contributors;
+    this.fetchFollowerData();
+},
+
       });
   }
 


### PR DESCRIPTION
## Description
This PR restores the fallback behavior for the Contributors page by using
hardcoded placeholder contributor data when the API is unavailable or the
API key is not configured.

## Related Issue
Fixes #189

## Motivation and Context
Previously, when the API request failed, the Contributors page displayed an
empty state. This change improves UX by ensuring users still see example
contributors, matching the expected behavior described in the issue.

## Screenshots
Attached (verified locally using ng serve without backend)

## Types of changes
- [x] Bug fix (non-breaking)

## Checklist
- [x] My code follows the code style of this project
- [x] No documentation changes required
- [x] Verified locally
