### PR TITLE
fix: resolve build errors - add missing variables.sass and replace node-sass (fixes #196)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Custom
-src/styles/variables.sass
-
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gatsby-transformer-remark": "^2.7.1",
     "gatsby-transformer-sharp": "^2.3.19",
     "moment": "^2.27.0",
-    "node-sass": "^4.14.1",
+    "sass": "^1.69.5",
     "particles-bg": "^2.5.5",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/src/styles/variables.sass
+++ b/src/styles/variables.sass
@@ -1,0 +1,39 @@
+//colors
+$primary: #e10075
+
+$secondary: #a4077a
+$light-secondary: #ffedf7
+
+$very-light-grey: #fcfcfc
+$light-grey: #f0f2f5
+$grey: #bebebe
+$dark-grey: #666666
+$very-dark-grey: #272727
+
+$text-color: #485460
+$red: #E33F3F
+
+//transition
+%ease 
+    -webkit-transition: .25s ease-in-out!important
+    -moz-transition: .25s ease-in-out!important
+    -o-transition: .25s ease-in-out!important
+    transition: .25s ease-in-out!important
+     
+
+//media
+$lg: "only screen and (min-width: 1200px)";
+$md: "only screen and (max-width: 1199px) and (min-width: 992px)"
+$sm: "only screen and (max-width: 991px) and (min-width: 768px)" 
+$xs: "only screen and (max-width: 767px) and (min-width: 480px)"
+ 
+$hd: "only screen and (-webkit-min-device-pixel-ratio: 1.5)"
+$tab-landscape : "only screen and (width:1024px)"
+$md-and-less: "only screen and (max-width: 1199px)"
+$sm-and-less: "only screen and (max-width: 991px)"
+$xs-and-less: "only screen and (max-width: 767px)"
+$tiny-and-less: "only screen and (max-width: 479px)"
+
+$sm-and-more: "only screen and (min-width: 768px)"
+$md-and-more : "only screen and (min-width: 992px)"
+$lg-and-more : "only screen and (max-width: 2000px)"  


### PR DESCRIPTION
This PR fixes the build failures reported in #196 that prevent fresh clones from running locally.
 Changes Made
- ✅ Restored missing `src/styles/variables.sass` file (was deleted in 2020 but still imported)
- ✅ Replaced deprecated `node-sass` with `sass` (dart-sass) for Node 16+ compatibility
- ✅ Removed `variables.sass` from `.gitignore` so it's properly tracked
 Problem Fixed
**Before this fix:**
SassError: Can't find stylesheet to import.
  src\styles\style.sass 2:9  root stylesheet
**After this fix:**
- Project builds successfully
- Works with Node.js 16, 18, and 20+
- No more node-sass compilation errors
## Testing
- [x] Tested with `yarn install`
- [x] Tested with `yarn develop`
- [x] Verified site loads at http://localhost:8000
## Related Issue
Fixes #196