### PR TITLE
Enhance contributor search page UI and profile card with detailed data

### DIFF
--- a/webiu-ui/src/app/components/profile-card/profile-card.component.html
+++ b/webiu-ui/src/app/components/profile-card/profile-card.component.html
@@ -4,9 +4,13 @@
   <span class="profile-username" (click)="onUsernameClick(login)">
     {{ login }}
   </span>
-  <p class="profile-contributions">Contributions: {{ contributions }}</p>
-  <!-- <p class="profile-followers">Followers: {{ followers }}</p>
-  <p class="profile-following">Following: {{ following }}</p> -->
+  <p class="profile-contributions">{{ contributions }} commits</p>
+
+  <!-- Top Repos Chips -->
+  <div class="repo-chips" *ngIf="repos && repos.length > 0">
+    <span class="repo-chip" *ngFor="let repo of topRepos">{{ repo }}</span>
+    <span class="repo-more" *ngIf="repos.length > 3">+{{ repos.length - 3 }} more</span>
+  </div>
 
   <div class="profile-github">
     <div class="github-icon">

--- a/webiu-ui/src/app/components/profile-card/profile-card.component.scss
+++ b/webiu-ui/src/app/components/profile-card/profile-card.component.scss
@@ -61,8 +61,43 @@
 .profile-username {
   cursor: pointer;
   color: var(--profile-username-color);
-  // text-decoration: underline;
   margin-bottom: 5px;
+}
+
+.profile-contributions {
+  font-size: 0.85rem;
+  color: var(--font-light, #898989);
+  margin-bottom: 8px;
+}
+
+.repo-chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 12px;
+  margin-bottom: 4px;
+}
+
+.repo-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  background: var(--select-bg, #e9f6ff);
+  color: var(--primary-color, #3498db);
+  border: 1px solid var(--select-border, #ddd);
+  border-radius: 12px;
+  white-space: nowrap;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-more {
+  font-size: 0.72rem;
+  color: var(--font-light, #898989);
+  align-self: center;
 }
 
 /* Media Queries */

--- a/webiu-ui/src/app/components/profile-card/profile-card.component.ts
+++ b/webiu-ui/src/app/components/profile-card/profile-card.component.ts
@@ -1,25 +1,28 @@
-
 import { CommonModule } from "@angular/common";
-import { Component , Input, Output, EventEmitter } from "@angular/core";
+import { Component, Input, Output, EventEmitter } from "@angular/core";
 
 @Component({
-    selector: 'app-profile-card',
-    standalone:true,
-    imports:[CommonModule],
-    templateUrl:'./profile-card.component.html',
-    styleUrl:'./profile-card.component.scss',
+  selector: 'app-profile-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './profile-card.component.html',
+  styleUrl: './profile-card.component.scss',
 })
-export class ProfileCardComponent{
-  @Input()  login!: string;
-  @Input()  repos!: string[];
-  @Input() avatar_url!:string;
+export class ProfileCardComponent {
+  @Input() login!: string;
+  @Input() repos!: string[];
+  @Input() avatar_url!: string;
   @Input() contributions!: number;
   @Input() followers!: number;
   @Input() following!: number;
 
   @Output() usernameClick = new EventEmitter<string>();
 
-onUsernameClick(username: string) {
-  this.usernameClick.emit(username); // Emit the login value to the parent
-}
+  get topRepos(): string[] {
+    return this.repos ? this.repos.slice(0, 3) : [];
+  }
+
+  onUsernameClick(username: string) {
+    this.usernameClick.emit(username);
+  }
 }

--- a/webiu-ui/src/app/page/contributor-search/contributor-search.component.html
+++ b/webiu-ui/src/app/page/contributor-search/contributor-search.component.html
@@ -14,12 +14,32 @@
     <aside class="sidebar">
       <div class="profile-card">
         <img [src]="userProfile.avatar_url" alt="{{ userProfile.login }}'s avatar" class="profile-avatar" />
-        <h2 class="profile-name">{{ userProfile.login }}</h2>
+        <h2 class="profile-name">{{ userProfile.name || userProfile.login }}</h2>
+        <p class="profile-login" *ngIf="userProfile.name">&#64;{{ userProfile.login }}</p>
+        <p class="profile-bio" *ngIf="userProfile.bio">{{ userProfile.bio }}</p>
+
         <button (click)="openGitHubProfile(userProfile.html_url)" class="github-link-btn">
           <i class="fab fa-github"></i>
           <span>View on GitHub</span>
         </button>
 
+        <!-- Profile Meta -->
+        <div class="profile-meta">
+          <div class="meta-item" *ngIf="userProfile.location">
+            <i class="fas fa-map-marker-alt"></i>
+            <span>{{ userProfile.location }}</span>
+          </div>
+          <div class="meta-item" *ngIf="memberSince">
+            <i class="fas fa-calendar-alt"></i>
+            <span>Member since {{ memberSince }}</span>
+          </div>
+          <div class="meta-item">
+            <i class="fas fa-users"></i>
+            <span>{{ userProfile.followers }} followers &middot; {{ userProfile.following }} following</span>
+          </div>
+        </div>
+
+        <!-- Stats -->
         <div class="profile-stats">
           <div class="stat">
             <span class="stat-value">{{ issues.length }}</span>
@@ -32,6 +52,41 @@
           <div class="stat">
             <span class="stat-value">{{ uniqueRepositories.length }}</span>
             <span class="stat-label">Repos</span>
+          </div>
+        </div>
+
+        <!-- Open / Closed Breakdown -->
+        <div class="breakdown-section">
+          <h4 class="breakdown-title">Issues Breakdown</h4>
+          <div class="breakdown-bar">
+            <div
+              class="bar-segment open"
+              [style.width.%]="issues.length ? (openIssues / issues.length) * 100 : 0"
+            ></div>
+            <div
+              class="bar-segment closed"
+              [style.width.%]="issues.length ? (closedIssues / issues.length) * 100 : 0"
+            ></div>
+          </div>
+          <div class="breakdown-legend">
+            <span class="legend-item"><i class="fas fa-circle open-dot"></i> {{ openIssues }} Open</span>
+            <span class="legend-item"><i class="fas fa-circle closed-dot"></i> {{ closedIssues }} Closed</span>
+          </div>
+
+          <h4 class="breakdown-title" style="margin-top: 16px;">PR Breakdown</h4>
+          <div class="breakdown-bar">
+            <div
+              class="bar-segment pr-open"
+              [style.width.%]="pullRequests.length ? (openPRs / pullRequests.length) * 100 : 0"
+            ></div>
+            <div
+              class="bar-segment pr-closed"
+              [style.width.%]="pullRequests.length ? (mergedOrClosedPRs / pullRequests.length) * 100 : 0"
+            ></div>
+          </div>
+          <div class="breakdown-legend">
+            <span class="legend-item"><i class="fas fa-circle pr-open-dot"></i> {{ openPRs }} Open</span>
+            <span class="legend-item"><i class="fas fa-circle pr-closed-dot"></i> {{ mergedOrClosedPRs }} Merged/Closed</span>
           </div>
         </div>
       </div>

--- a/webiu-ui/src/app/page/contributor-search/contributor-search.component.scss
+++ b/webiu-ui/src/app/page/contributor-search/contributor-search.component.scss
@@ -67,6 +67,21 @@
   font-size: 1.25rem;
   font-weight: 700;
   color: var(--primary-dark, #0a0a15);
+  margin-bottom: 2px;
+  text-align: center;
+}
+
+.profile-login {
+  font-size: 0.85rem;
+  color: var(--font-light, #898989);
+  margin-bottom: 8px;
+}
+
+.profile-bio {
+  font-size: 0.85rem;
+  color: var(--font-color-dark, #333);
+  text-align: center;
+  line-height: 1.4;
   margin-bottom: 12px;
 }
 
@@ -94,11 +109,39 @@
   }
 }
 
+// ─── Profile Meta ───
+
+.profile-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--profile-box-border, #e0e0e0);
+  margin-bottom: 16px;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--font-light, #898989);
+
+  i {
+    width: 14px;
+    text-align: center;
+    font-size: 0.75rem;
+  }
+}
+
 .profile-stats {
   display: flex;
   width: 100%;
-  border-top: 1px solid var(--profile-box-border, #e0e0e0);
-  padding-top: 20px;
+  padding-top: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--profile-box-border, #e0e0e0);
+  margin-bottom: 16px;
   justify-content: space-around;
 }
 
@@ -324,6 +367,86 @@
     font-size: 0.95rem;
     color: var(--font-light, #898989);
   }
+}
+
+// ─── Breakdown Bars ───
+
+.breakdown-section {
+  width: 100%;
+}
+
+.breakdown-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--font-light, #898989);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.breakdown-bar {
+  display: flex;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--cards-container, #f2f2f2);
+  margin-bottom: 6px;
+}
+
+.bar-segment {
+  height: 100%;
+  min-width: 2px;
+  transition: width 0.4s ease;
+
+  &.open {
+    background: #2e7d32;
+  }
+
+  &.closed {
+    background: #7b1fa2;
+  }
+
+  &.pr-open {
+    background: #1565c0;
+  }
+
+  &.pr-closed {
+    background: #6a1b9a;
+  }
+}
+
+.breakdown-legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--font-light, #898989);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.open-dot {
+  color: #2e7d32;
+  font-size: 0.5rem;
+}
+
+.closed-dot {
+  color: #7b1fa2;
+  font-size: 0.5rem;
+}
+
+.pr-open-dot {
+  color: #1565c0;
+  font-size: 0.5rem;
+}
+
+.pr-closed-dot {
+  color: #6a1b9a;
+  font-size: 0.5rem;
 }
 
 // ─── Dark Mode ───

--- a/webiu-ui/src/app/page/contributor-search/contributor-search.component.ts
+++ b/webiu-ui/src/app/page/contributor-search/contributor-search.component.ts
@@ -24,8 +24,17 @@ export class ContributorSearchComponent {
   errorMessage: string = '';
   loading: boolean = false;
   activeView: 'issues' | 'pullRequests' = 'issues';
-  userProfile: { login: string; avatar_url: string; html_url: string } | null =
-    null;
+  userProfile: {
+    login: string;
+    avatar_url: string;
+    html_url: string;
+    name: string | null;
+    bio: string | null;
+    location: string | null;
+    followers: number;
+    following: number;
+    created_at: string;
+  } | null = null;
   private apiUrl = `${environment.serverUrl}/api/contributor`;
 
   constructor(private route: ActivatedRoute) { }
@@ -67,6 +76,12 @@ export class ContributorSearchComponent {
         login: userProfileResponse.data.login,
         avatar_url: userProfileResponse.data.avatar_url,
         html_url: userProfileResponse.data.html_url,
+        name: userProfileResponse.data.name,
+        bio: userProfileResponse.data.bio,
+        location: userProfileResponse.data.location,
+        followers: userProfileResponse.data.followers || 0,
+        following: userProfileResponse.data.following || 0,
+        created_at: userProfileResponse.data.created_at,
       };
 
       this.extractRepositories();
@@ -127,5 +142,27 @@ export class ContributorSearchComponent {
     return (
       this.filteredIssues.length > 0 || this.filteredPullRequests.length > 0
     );
+  }
+
+  get openIssues(): number {
+    return this.issues.filter((i) => !i.closed_at).length;
+  }
+
+  get closedIssues(): number {
+    return this.issues.filter((i) => i.closed_at).length;
+  }
+
+  get openPRs(): number {
+    return this.pullRequests.filter((pr) => !pr.closed_at).length;
+  }
+
+  get mergedOrClosedPRs(): number {
+    return this.pullRequests.filter((pr) => pr.closed_at).length;
+  }
+
+  get memberSince(): string {
+    if (!this.userProfile?.created_at) return '';
+    const date = new Date(this.userProfile.created_at);
+    return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
   }
 }

--- a/webiu-ui/src/app/page/contributors/contributors.component.html
+++ b/webiu-ui/src/app/page/contributors/contributors.component.html
@@ -45,8 +45,9 @@
 
     <div class="contributors-grid" *ngIf="!isLoading">
       <app-profile-card *ngFor="let profile of displayProfiles; trackBy: trackByFn" [login]="profile.login"
-        [contributions]="profile.contributions" [avatar_url]="profile.avatar_url" [followers]="profile.followers"
-        [following]="profile.following" (usernameClick)="onUsernameClick($event)"></app-profile-card>
+        [contributions]="profile.contributions" [avatar_url]="profile.avatar_url" [repos]="profile.repos"
+        [followers]="profile.followers" [following]="profile.following"
+        (usernameClick)="onUsernameClick($event)"></app-profile-card>
     </div>
 
     <p *ngIf="!isLoading && displayProfiles.length === 0" class="no-contributors-message">


### PR DESCRIPTION
Redesigned the contributor search page with a clean two-column layout, sticky profile sidebar with bio/location/followers/member-since info, and open vs closed breakdown bars for issues and PRs. Added repo name chips to the contributors list profile card, fixed the contributions label to say "commits" for clarity, and standardized all API URLs to use environment.serverUrl.