### PR TITLE
Refactor filters to native dropdowns and enable Docker hot-reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   webiu-server:
@@ -11,12 +11,15 @@ services:
       - NODE_ENV=development
     volumes:
       - ./webiu-server:/usr/src/app
-    command: ['npm', 'start']
+    command: ["npm", "start"]
 
   webiu-ui:
     build:
       context: ./webiu-ui
     container_name: webiu-ui
+    volumes:
+      - ./webiu-ui:/usr/src/app
+      - /usr/src/app/node_modules
     ports:
       - 4200:4200
     expose:

--- a/webiu-ui/src/app/page/contributors/contributors.component.html
+++ b/webiu-ui/src/app/page/contributors/contributors.component.html
@@ -3,11 +3,20 @@
     <div class="search-container">
       <div class="search-wrapper">
         <div class="input-container">
-          <input type="text" class="search-input" placeholder="search contributors" [formControl]="searchText" />
+          <input
+            type="text"
+            class="search-input"
+            placeholder="search contributors"
+            [formControl]="searchText"
+          />
           @if (searchText.value) {
-          <button class="clear-icon" (click)="clearSearch()" title="Clear search">
-            <i class="fas fa-times"></i>
-          </button>
+            <button
+              class="clear-icon"
+              (click)="clearSearch()"
+              title="Clear search"
+            >
+              <i class="fas fa-times"></i>
+            </button>
           }
         </div>
         <button class="search-button" (click)="filterProfiles()">
@@ -19,23 +28,25 @@
     <div class="filters-section">
       <div class="filter-group">
         <span>Filter by Repository</span>
-        <input class="filter-input" list="repos" placeholder="All Repositories" (change)="onRepoChange($event)">
-        <datalist id="repos">
+        <select class="filter-select" (change)="onRepoChange($event)">
+          <option value="">All Repositories</option>
           @for (repo of allRepos; track repo) {
-          <option [value]="repo"></option>
+            <option [value]="repo">{{ repo }}</option>
           }
-        </datalist>
+        </select>
       </div>
 
       <div class="filter-group">
         <span>Filter by Contributions</span>
-        <input class="filter-input" list="contributions" placeholder="All Contributions"
-          (change)="onContributionRangeChange($event)">
-        <datalist id="contributions">
+        <select
+          class="filter-select"
+          (change)="onContributionRangeChange($event)"
+        >
+          <option value="">All Contributions</option>
           @for (range of contributionRanges; track range) {
-          <option [value]="range.label"></option>
+            <option [value]="range.label">{{ range.label }}</option>
           }
-        </datalist>
+        </select>
       </div>
 
       <div class="filter-group">
@@ -44,63 +55,94 @@
           <option value="">Default</option>
           <option value="name-asc">Name (A-Z)</option>
           <option value="name-desc">Name (Z-A)</option>
-          <option value="contributions-desc">Contributions (High to Low)</option>
+          <option value="contributions-desc">
+            Contributions (High to Low)
+          </option>
           <option value="contributions-asc">Contributions (Low to High)</option>
         </select>
       </div>
     </div>
 
     @if (isLoading) {
-    <app-loading-spinner message="Loading contributors..."></app-loading-spinner>
+      <app-loading-spinner
+        message="Loading contributors..."
+      ></app-loading-spinner>
     }
 
     @if (!isLoading) {
-    <div class="contributors-grid">
-      @for (profile of displayProfiles; track trackByFn($index, profile)) {
-      <app-profile-card [login]="profile.login" [contributions]="profile.contributions"
-        [avatar_url]="profile.avatar_url" [repos]="profile.repos" [followers]="profile.followers"
-        [following]="profile.following" (usernameClick)="onUsernameClick($event)"></app-profile-card>
-      }
-    </div>
+      <div class="contributors-grid">
+        @for (profile of displayProfiles; track trackByFn($index, profile)) {
+          <app-profile-card
+            [login]="profile.login"
+            [contributions]="profile.contributions"
+            [avatar_url]="profile.avatar_url"
+            [repos]="profile.repos"
+            [followers]="profile.followers"
+            [following]="profile.following"
+            (usernameClick)="onUsernameClick($event)"
+          ></app-profile-card>
+        }
+      </div>
     }
 
     @if (!isLoading && displayProfiles.length === 0) {
-    <p class="no-contributors-message">
-      No contributors found matching the search criteria
-    </p>
+      <p class="no-contributors-message">
+        No contributors found matching the search criteria
+      </p>
     }
 
     @if (!isLoading && displayProfiles && displayProfiles.length > 0) {
-    <div class="pagination-container">
-      <div class="pagination">
-        <button (click)="goToFirstPage()" [disabled]="currentPage === 1" title="First Page">
-          <i class="fa fa-angle-double-left"></i>
-        </button>
-        <button (click)="prevPage()" [disabled]="currentPage === 1" title="Previous Page">
-          <i class="fa fa-angle-left"></i>
-        </button>
-        <span>Page {{ currentPage }} of {{ totalPages }}</span>
-        <button (click)="nextPage()" [disabled]="currentPage === totalPages" title="Next Page">
-          <i class="fa fa-angle-right"></i>
-        </button>
-        <button (click)="goToLastPage()" [disabled]="currentPage === totalPages" title="Last Page">
-          <i class="fa fa-angle-double-right"></i>
-        </button>
+      <div class="pagination-container">
+        <div class="pagination">
+          <button
+            (click)="goToFirstPage()"
+            [disabled]="currentPage === 1"
+            title="First Page"
+          >
+            <i class="fa fa-angle-double-left"></i>
+          </button>
+          <button
+            (click)="prevPage()"
+            [disabled]="currentPage === 1"
+            title="Previous Page"
+          >
+            <i class="fa fa-angle-left"></i>
+          </button>
+          <span>Page {{ currentPage }} of {{ totalPages }}</span>
+          <button
+            (click)="nextPage()"
+            [disabled]="currentPage === totalPages"
+            title="Next Page"
+          >
+            <i class="fa fa-angle-right"></i>
+          </button>
+          <button
+            (click)="goToLastPage()"
+            [disabled]="currentPage === totalPages"
+            title="Last Page"
+          >
+            <i class="fa fa-angle-double-right"></i>
+          </button>
+        </div>
+        <div class="items-per-page">
+          <label for="itemsPerPage">Show:</label>
+          <select id="itemsPerPage" (change)="onItemsPerPageChange($event)">
+            <option [value]="9" [selected]="profilesPerPage === 9">9</option>
+            <option [value]="18" [selected]="profilesPerPage === 18">18</option>
+            <option [value]="27" [selected]="profilesPerPage === 27">27</option>
+            <option [value]="50" [selected]="profilesPerPage === 50">50</option>
+          </select>
+        </div>
       </div>
-      <div class="items-per-page">
-        <label for="itemsPerPage">Show:</label>
-        <select id="itemsPerPage" (change)="onItemsPerPageChange($event)">
-          <option [value]="9" [selected]="profilesPerPage === 9">9</option>
-          <option [value]="18" [selected]="profilesPerPage === 18">18</option>
-          <option [value]="27" [selected]="profilesPerPage === 27">27</option>
-          <option [value]="50" [selected]="profilesPerPage === 50">50</option>
-        </select>
-      </div>
-    </div>
     }
   </section>
 
   <button class="back-to-top" (click)="scrollToTop()" [class.show]="showButton">
-    <img src="../../../assets/up-arrow.svg" alt="Back to Top" width="24" height="24" />
+    <img
+      src="../../../assets/up-arrow.svg"
+      alt="Back to Top"
+      width="24"
+      height="24"
+    />
   </button>
 </div>

--- a/webiu-ui/src/app/page/contributors/contributors.component.ts
+++ b/webiu-ui/src/app/page/contributors/contributors.component.ts
@@ -16,8 +16,6 @@ interface ContributionRange {
   max: number | null;
 }
 
-
-
 @Component({
   selector: 'app-contributors',
   standalone: true,
@@ -26,7 +24,7 @@ interface ContributionRange {
     HttpClientModule,
     ReactiveFormsModule,
     ProfileCardComponent,
-    LoadingSpinnerComponent
+    LoadingSpinnerComponent,
   ],
   templateUrl: './contributors.component.html',
   styleUrls: ['./contributors.component.scss'],
@@ -53,7 +51,6 @@ export class ContributorsComponent implements OnInit {
     { label: '500+', min: 500, max: null },
   ];
 
-
   currentPage = 1;
   profilesPerPage = 9;
   totalPages = 1;
@@ -72,9 +69,9 @@ export class ContributorsComponent implements OnInit {
 
   getProfiles() {
     this.http
-      .get<Contributor[]>(
-        `${environment.serverUrl}/api/contributor/contributors`
-      )
+      .get<
+        Contributor[]
+      >(`${environment.serverUrl}/api/contributor/contributors`)
       .subscribe({
         next: (res) => {
           this.contributors = res || [];
@@ -97,7 +94,7 @@ export class ContributorsComponent implements OnInit {
     const requests = this.contributors.map((contributor) =>
       this.http
         .get<{ followers?: number; following?: number }>(
-          `${environment.serverUrl}/api/user/followersAndFollowing/${contributor.login}`
+          `${environment.serverUrl}/api/user/followersAndFollowing/${contributor.login}`,
         )
         .toPromise()
         .then((data) => {
@@ -107,7 +104,7 @@ export class ContributorsComponent implements OnInit {
         .catch(() => {
           contributor.followers = 0;
           contributor.following = 0;
-        })
+        }),
     );
 
     Promise.all(requests).then(() => {
@@ -122,7 +119,7 @@ export class ContributorsComponent implements OnInit {
     this.commonUtil.commonProfiles = this.profiles;
     this.allRepos = this.getUniqueRepos();
     this.totalPages = Math.ceil(
-      (this.profiles.length || 0) / this.profilesPerPage
+      (this.profiles.length || 0) / this.profilesPerPage,
     );
     this.filterProfiles();
     this.isLoading = false;
@@ -139,15 +136,15 @@ export class ContributorsComponent implements OnInit {
   }
 
   onRepoChange(event: Event) {
-    const inputElement = event.target as HTMLInputElement;
-    this.selectedRepo = inputElement.value;
+    const selectElement = event.target as HTMLSelectElement;
+    this.selectedRepo = selectElement.value;
     this.currentPage = 1;
     this.filterProfiles();
   }
 
   onContributionRangeChange(event: Event) {
-    const inputElement = event.target as HTMLInputElement;
-    this.selectedContributionRange = inputElement.value;
+    const selectElement = event.target as HTMLSelectElement;
+    this.selectedContributionRange = selectElement.value;
     this.currentPage = 1;
     this.filterProfiles();
   }
@@ -164,25 +161,25 @@ export class ContributorsComponent implements OnInit {
 
     if (searchTextValue) {
       filteredProfiles = filteredProfiles.filter((profile) =>
-        profile.login.toLowerCase().includes(searchTextValue)
+        profile.login.toLowerCase().includes(searchTextValue),
       );
     }
 
     if (this.selectedRepo) {
       filteredProfiles = filteredProfiles.filter((profile) =>
-        profile.repos?.includes(this.selectedRepo)
+        profile.repos?.includes(this.selectedRepo),
       );
     }
 
     if (this.selectedContributionRange) {
       const range = this.contributionRanges.find(
-        (r) => r.label === this.selectedContributionRange
+        (r) => r.label === this.selectedContributionRange,
       );
       if (range) {
         filteredProfiles = filteredProfiles.filter(
           (profile) =>
             profile.contributions >= range.min &&
-            (range.max === null || profile.contributions <= range.max)
+            (range.max === null || profile.contributions <= range.max),
         );
       }
     }
@@ -197,7 +194,7 @@ export class ContributorsComponent implements OnInit {
     const startIndex = (this.currentPage - 1) * this.profilesPerPage;
     this.displayProfiles = filteredProfiles.slice(
       startIndex,
-      startIndex + this.profilesPerPage
+      startIndex + this.profilesPerPage,
     );
   }
 
@@ -232,8 +229,6 @@ export class ContributorsComponent implements OnInit {
     this.filterProfiles();
   }
 
-
-
   onSortChange(event: Event) {
     const selectElement = event.target as HTMLSelectElement;
     this.selectedSort = selectElement.value;
@@ -246,9 +241,13 @@ export class ContributorsComponent implements OnInit {
 
     switch (sortBy) {
       case 'name-asc':
-        return sorted.sort((a, b) => a.login.toLowerCase().localeCompare(b.login.toLowerCase()));
+        return sorted.sort((a, b) =>
+          a.login.toLowerCase().localeCompare(b.login.toLowerCase()),
+        );
       case 'name-desc':
-        return sorted.sort((a, b) => b.login.toLowerCase().localeCompare(a.login.toLowerCase()));
+        return sorted.sort((a, b) =>
+          b.login.toLowerCase().localeCompare(a.login.toLowerCase()),
+        );
       case 'contributions-desc':
         return sorted.sort((a, b) => b.contributions - a.contributions);
       case 'contributions-asc':


### PR DESCRIPTION
## Description

Refactored both the "Filter by Repository" and "Filter by Contributions" filters to use native dropdowns (`<select>`) instead of datalist-based inputs. This ensures consistent styling, native dropdown behavior, and accessible interaction across the UI.

Additionally, updated `docker-compose.yml` to mount the frontend source code as a volume, enabling hot-reloading during development and improving developer experience.

Fixes #216 

## Result (Video)
<div align="center">
  <video src="https://github.com/user-attachments/assets/35dfe97d-e964-4804-866f-a1ece61a375b" height="300" controls></video>
</div>


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual testing was performed on the Contributors page to verify dropdown behavior and filtering logic, as well as Docker hot-reload functionality.

Steps:
1. Run the app locally (`ng serve`) and open `/contributors`.
2. Verify both "Filter by Repository" and "Filter by Contributions" open on first click.
3. Select options in each filter → contributor list updates correctly.
4. Select "All" options → list resets.
5. Confirm styling and behavior match the "Sort By" dropdown.
6. Run via Docker (`docker compose up`) and edit frontend code → changes hot-reload without container restart.

- [x] Repository filter works correctly
- [x] Contributions filter works correctly
- [x] Reset options restore full list
- [x] Styling consistent with other filters
- [x] Docker hot-reload verified
- [x] Existing unit tests pass locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes