### PR TITLE
feat: add getUserFollowersAndFollowing API endpoint (NestJS)

### DIFF
--- a/webiu-server/src/contributor/contributor.controller.ts
+++ b/webiu-server/src/contributor/contributor.controller.ts
@@ -28,4 +28,10 @@ export class ContributorController {
   async getUserStats(@Param('username') username: string) {
     return this.contributorService.getUserStats(username);
   }
+
+  @Get('followers/:username')
+  @Header('Cache-Control', 'public, max-age=300')
+  async getUserFollowersAndFollowing(@Param('username') username: string) {
+    return this.contributorService.getUserFollowersAndFollowing(username);
+  }
 }

--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -144,4 +144,20 @@ export class ContributorService {
       throw new InternalServerErrorException('Internal server error');
     }
   }
+
+  async getUserFollowersAndFollowing(username: string) {
+    try {
+      const result =
+        await this.githubService.getUserFollowersAndFollowing(username);
+      return result;
+    } catch (error) {
+      console.error(
+        'Error fetching user followers and following:',
+        error.response ? error.response.data : error.message,
+      );
+      throw new InternalServerErrorException(
+        'Failed to fetch followers and following data',
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Added the missing getUserFollowersAndFollowing API endpoint to the NestJS backend.

## Changes Made
1. **GithubService** - Added  method
2. **ContributorService** - Added  method  
3. **ContributorController** - Added  endpoint

## Endpoint
`GET /api/contributor/followers/:username`

Returns:
```json
{
  "followers": 100,
  "following": 50
}
```

## Why this fix is needed
- Issue #214 reported the followers API was returning hardcoded {0:0}
- The old Express.js code was migrated to NestJS but this endpoint was not included
- This fix restores the functionality in the new NestJS structure

## Testing
- Lint passes ✓
- Follows existing code patterns in the codebase
- Uses caching like other endpoints (5 min TTL)

## Fixes
Fixes #214