### PR TITLE
[Fix]: navigation drawer not closing after route change

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -26,9 +26,14 @@ export class NavbarComponent implements OnInit {
   ngOnInit(): void {
     this.isSunVisible = !this.themeService.isDarkMode();
     this.router.events
-      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .pipe(
+        filter(
+          (event): event is NavigationEnd => event instanceof NavigationEnd,
+        ),
+      )
       .subscribe((event: NavigationEnd) => {
         this.currentRoute = event.url;
+        this.isMenuOpen = false;
       });
 
     const queryParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Description

This PR fixes an issue where the navigation drawer remained open after selecting a navigation item and navigating to another page. The open drawer could obscure the newly loaded content and required manual dismissal by the user.

The navigation behavior has been updated so that the drawer automatically closes when a navigation link is clicked, aligning with standard overlay/mobile navigation UX patterns and improving usability across pages.

Fixes #222

### Result (Video)

https://github.com/user-attachments/assets/e2b67af1-7c04-4cc2-b1b4-05652a68ee79

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

1. Open the navigation drawer
2. Click any navigation item (e.g., Home, Projects, Contributors)
3. Confirm:
   - Navigation occurs correctly
   - Drawer closes automatically after route change
4. Repeat across multiple pages

- [x] Navigation closes on route change
- [x] Routing behavior unchanged
- [x] No console errors introduced

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
