### PR TITLE
feat: add Helmet middleware to set HTTP security headers

### DIFF
--- a/webiu-server/package-lock.json
+++ b/webiu-server/package-lock.json
@@ -21,6 +21,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "google-auth-library": "^9.15.0",
+        "helmet": "^8.1.0",
         "mongoose": "^8.8.1",
         "nodemailer": "^6.9.16",
         "passport": "^0.7.0",
@@ -5797,6 +5798,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/webiu-server/package.json
+++ b/webiu-server/package.json
@@ -30,6 +30,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "google-auth-library": "^9.15.0",
+    "helmet": "^8.1.0",
     "mongoose": "^8.8.1",
     "nodemailer": "^6.9.16",
     "passport": "^0.7.0",

--- a/webiu-server/src/main.ts
+++ b/webiu-server/src/main.ts
@@ -2,10 +2,13 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import helmet from 'helmet';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
+
+  app.use(helmet());
 
   const frontendUrl = configService.get<string>(
     'FRONTEND_BASE_URL',


### PR DESCRIPTION
 ## Description
  The backend had no HTTP security headers configured. This PR adds the `helmet` middleware in `main.ts` to automatically set securityheaders on every response.

Fixes #265 
  ## Type of change
  - [x] New feature (non-breaking change which adds functionality)

  ## How Has This Been Tested?
  curl -I http://localhost:5050/api/projects/projects
<img width="982" height="362" alt="image" src="https://github.com/user-attachments/assets/cb99663a-0f67-4641-bd57-c43b59c0168c" />


  Headers now present in every response:
  - Content-Security-Policy
  - X-Frame-Options: SAMEORIGIN
  - X-Content-Type-Options: nosniff
  - Strict-Transport-Security: max-age=31536000; includeSubDomains
  - Referrer-Policy: no-referrer

  ## Checklist:
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published in downstream modules