### PR TITLE
fix: update footer social media links with official C2SI handles

### DIFF
--- a/webiu-ui/src/app/components/footer/footer.component.html
+++ b/webiu-ui/src/app/components/footer/footer.component.html
@@ -40,6 +40,22 @@
       <ul>
         <li>
           <a
+            href="https://discord.gg/77PjM2P3"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Discord</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://www.linkedin.com/company/c2si/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >LinkedIn</a
+          >
+        </li>
+        <li>
+          <a
             href="https://github.com/c2siorg"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Description
This PR replaces the placeholder `#` links in the footer with the official social media URLs for C2SI. 

**Changes:**
- Updated Discord, LinkedIn, and GitHub links.
- Added `target="_blank"` and `rel="noopener noreferrer"` for better UX and security.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Tested locally and links are working correctly