### PR TITLE
fix: replace N+1 contributor API calls with single batch endpoint

### DIFF
--- a/webiu-server/src/user/dto/batch-social.dto.ts
+++ b/webiu-server/src/user/dto/batch-social.dto.ts
@@ -1,0 +1,14 @@
+import {
+  IsArray,
+  IsString,
+  ArrayNotEmpty,
+  ArrayMaxSize,
+} from 'class-validator';
+
+export class BatchSocialDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(500)
+  @IsString({ each: true })
+  usernames: string[];
+}

--- a/webiu-server/src/user/user.controller.spec.ts
+++ b/webiu-server/src/user/user.controller.spec.ts
@@ -1,14 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { GithubService } from '../github/github.service';
 
 describe('UserController', () => {
   let controller: UserController;
 
+  const mockGithubService = {
+    getPublicUserProfile: jest.fn(),
+    getUserFollowersAndFollowing: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService],
+      providers: [
+        UserService,
+        { provide: GithubService, useValue: mockGithubService },
+      ],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/webiu-server/src/user/user.controller.ts
+++ b/webiu-server/src/user/user.controller.ts
@@ -1,7 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
 import { UserService } from './user.service';
+import { BatchSocialDto } from './dto/batch-social.dto';
 
 @Controller('api/user')
 export class UserController {
   constructor(private userService: UserService) {}
+
+  @Get('followersAndFollowing/:username')
+  async getFollowersAndFollowing(@Param('username') username: string) {
+    return this.userService.getFollowersAndFollowing(username);
+  }
+
+  @Post('batch-social')
+  async batchSocial(@Body() dto: BatchSocialDto) {
+    return this.userService.batchFollowersAndFollowing(dto.usernames);
+  }
 }

--- a/webiu-server/src/user/user.service.spec.ts
+++ b/webiu-server/src/user/user.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { GithubService } from '../github/github.service';
 
 describe('UserService', () => {
   let service: UserService;
 
+  const mockGithubService = {
+    getPublicUserProfile: jest.fn(),
+    getUserFollowersAndFollowing: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        { provide: GithubService, useValue: mockGithubService },
+      ],
     }).compile();
 
     service = module.get<UserService>(UserService);

--- a/webiu-server/src/user/user.service.ts
+++ b/webiu-server/src/user/user.service.ts
@@ -1,4 +1,39 @@
 import { Injectable } from '@nestjs/common';
+import { GithubService } from '../github/github.service';
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(private githubService: GithubService) {}
+
+  async getFollowersAndFollowing(_username: string) {
+    // Placeholder implementation (same as original)
+    return { 0: 0 };
+  }
+
+  async batchFollowersAndFollowing(
+    usernames: string[],
+  ): Promise<Record<string, { followers: number; following: number }>> {
+    const map: Record<string, { followers: number; following: number }> = {};
+    const BATCH_SIZE = 10;
+
+    for (let i = 0; i < usernames.length; i += BATCH_SIZE) {
+      const batch = usernames.slice(i, i + BATCH_SIZE);
+      const results = await Promise.allSettled(
+        batch.map((username) =>
+          this.githubService
+            .getUserFollowersAndFollowing(username)
+            .then((data) => ({ username, ...data })),
+        ),
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          const { username, followers, following } = result.value;
+          map[username] = { followers, following };
+        }
+      }
+    }
+
+    return map;
+  }
+}


### PR DESCRIPTION
## Description                                                                                                                        
  The contributors page was making one HTTP request per contributor to fetch followers/following data. With 330 contributors in the org this resulted in 330+ individual API calls on every page load.                                              
                                                                            
  This PR introduces a `POST /api/user/batch-social` endpoint that accepts a list of usernames and returns all followers/following data n a single response. The frontend now makes one batch request instead of N individual ones.                                          

  Fixes #270 

  ## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested

 ### Network tab comparison:
  **- Before: 384 requests on page load**
   <img width="1470" height="790" alt="image" src="https://github.com/user-attachments/assets/9b1b5bf7-9c14-4bbe-adec-4976b2d17c68" />
  **- After: 56 requests on page load**
   <img width="1470" height="787" alt="image" src="https://github.com/user-attachments/assets/a109a3a1-986a-4e52-a93d-ee2b837128ca" />
  
Checklist:

                     
## Checklist:                                                                                                                         
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code                                                                                   
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                              
  - [ ] I have made corresponding changes to the documentation                                                                          
  - [x] My changes generate no new warnings                                                                                             
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published in downstream modules