### PR TITLE
  fix: move GitHub user profile API call from frontend to backend

### DIFF
--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -188,6 +188,18 @@ export class GithubService {
     return response.data;
   }
 
+  async getPublicUserProfile(username: string): Promise<any> {
+    const cacheKey = `user_profile_${username}`;
+    const cached = this.cacheService.get<any>(cacheKey);
+    if (cached) return cached;
+
+    const response = await axios.get(`${this.baseUrl}/users/${username}`, {
+      headers: this.headers,
+    });
+    this.cacheService.set(cacheKey, response.data, CACHE_TTL);
+    return response.data;
+  }
+
   async exchangeGithubCode(
     clientId: string,
     clientSecret: string,

--- a/webiu-server/src/user/user.controller.ts
+++ b/webiu-server/src/user/user.controller.ts
@@ -15,4 +15,9 @@ export class UserController {
   async batchSocial(@Body() dto: BatchSocialDto) {
     return this.userService.batchFollowersAndFollowing(dto.usernames);
   }
+
+  @Get('profile/:username')
+  async getUserProfile(@Param('username') username: string) {
+    return this.userService.getUserProfile(username);
+  }
 }

--- a/webiu-server/src/user/user.service.ts
+++ b/webiu-server/src/user/user.service.ts
@@ -6,7 +6,6 @@ export class UserService {
   constructor(private githubService: GithubService) {}
 
   async getFollowersAndFollowing(_username: string) {
-    // Placeholder implementation (same as original)
     return { 0: 0 };
   }
 
@@ -35,5 +34,9 @@ export class UserService {
     }
 
     return map;
+  }
+
+  async getUserProfile(username: string) {
+    return this.githubService.getPublicUserProfile(username);
   }
 }


### PR DESCRIPTION
## Description
  The contributor search page was calling `https://api.github.com/users/:username` directly from the browser using axios. This exposed the app to browser-side rate limits (60 req/hr unauthenticated) and bypassed backend caching and the server's GitHub token.

Fixes #299 

  This PR:
  - Adds `GET /api/user/profile/:username` backend endpoint backed by `GithubService` with caching
  - Replaces the direct axios call with Angular's `HttpClient` pointing to the new endpoint
  - Replaces deprecated `toPromise()` with `firstValueFrom()` from RxJS

  Fixes # (issue)

  ## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

  ## How Has This Been Tested?
  ```bash
  curl -s http://localhost:5050/api/user/profile/torvalds | jq '{login, name, followers, following, location}'
  ```
**Before**
<img width="970" height="131" alt="image" src="https://github.com/user-attachments/assets/35cfdbe7-42f7-4d1d-9bd5-b853f2183e88" />
**After**
<img width="972" height="133" alt="image" src="https://github.com/user-attachments/assets/c9734201-6b7a-438e-8bb4-9dfe81b65f71" />


  - Verified github.com filter in DevTools Network tab is empty after fix
  - Profile data loads correctly on contributor search page

**Before-**
<img width="913" height="276" alt="Screenshot 2026-02-21 at 1 02 13 AM" src="https://github.com/user-attachments/assets/626abe87-cd32-4958-b46c-68c849ab5981" />



**After**
<img width="756" height="295" alt="image" src="https://github.com/user-attachments/assets/d607e94e-3e39-4f17-8bf6-0ed0eb3809e3" />

  Checklist:
- [x] My code follows the style guidelines of this project                                                                            
  - [x] I have performed a self-review of my own code                                                                                 
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                              
  - [ ] I have made corresponding changes to the documentation                                                                          
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published in downstream modules