### PR TITLE
fix(navbar): guard JSON.parse of user query param against malformed input

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -42,7 +42,7 @@ export class NavbarComponent implements OnInit {
       try {
         this.user = JSON.parse(decodeURIComponent(user));
         this.isLoggedIn = true;
-      } catch {
+      } catch (e) {
         console.warn('Failed to parse user query param:', e);
         this.user = null;
         this.isLoggedIn = false;


### PR DESCRIPTION
## Description

Fixes #304 
`JSON.parse(decodeURIComponent(user))` in `navbar.component.ts` throws an uncaught `SyntaxError` if the `user` query parameter is malformed or tampered with. This causes the navbar to crash for that session.

This change wraps the parsing logic in a `try/catch` block. If parsing fails:

* `this.user` remains `null`
* `isLoggedIn` remains `false`

The application now degrades gracefully instead of crashing.