### PR TITLE
fix(env): add missing production environment file and fileReplacements

### DIFF
--- a/webiu-ui/angular.json
+++ b/webiu-ui/angular.json
@@ -32,6 +32,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/webiu-ui/src/environments/environment.prod.ts
+++ b/webiu-ui/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  serverUrl: 'https://webiu.c2si.ac.lk',
+};


### PR DESCRIPTION
**PR Title**
fix(env): add missing production environment file and fileReplacements

Fixes #306 

## Description

`environment.prod.ts` was missing, and `angular.json` did not define `fileReplacements` for the production configuration.

As a result, `ng build --configuration=production` used the development environment settings, causing `serverUrl` to resolve to `http://localhost:5050` in production builds.

This PR:

* Adds `environment.prod.ts` with `production: true`
* Configures `fileReplacements` in `angular.json` so the correct environment file is used during production builds

## Type of change

* Bug fix (non-breaking change that fixes an issue)