### PR TITLE
fix(user): validate username path params using existing UsernameDto

### DIFF
--- a/webiu-server/src/user/user.controller.ts
+++ b/webiu-server/src/user/user.controller.ts
@@ -1,13 +1,14 @@
 import { Controller, Get, Post, Param, Body } from '@nestjs/common';
 import { UserService } from './user.service';
 import { BatchSocialDto } from './dto/batch-social.dto';
+import { UsernameDto } from '../contributor/dto/username.dto';
 
 @Controller('api/user')
 export class UserController {
   constructor(private userService: UserService) {}
 
   @Get('followersAndFollowing/:username')
-  async getFollowersAndFollowing(@Param('username') username: string) {
+  async getFollowersAndFollowing(@Param() { username }: UsernameDto) {
     return this.userService.getFollowersAndFollowing(username);
   }
 
@@ -17,7 +18,7 @@ export class UserController {
   }
 
   @Get('profile/:username')
-  async getUserProfile(@Param('username') username: string) {
+  async getUserProfile(@Param() { username }: UsernameDto) {
     return this.userService.getUserProfile(username);
   }
 }


### PR DESCRIPTION
## Description

fixes #307 

`GET /api/user/followersAndFollowing/:username` and `GET /api/user/profile/:username` previously accepted any string as a username without validation. Invalid values were forwarded directly to the GitHub API.

This change reuses the existing `UsernameDto` from the contributor module, which enforces:

* Regex validation
* Maximum length of 39 characters
* Non-empty constraint

Both endpoints now use consistent validation aligned with existing patterns in the codebase.

## Type of change

* Bug fix (non-breaking change that fixes an issue)



<img width="984" height="246" alt="Screenshot 2026-02-21 at 4 07 12 AM" src="https://github.com/user-attachments/assets/b964895c-62f2-42c2-91f7-0a09ac8b9ae8" />
