### PR TITLE
fix: add query param validation to issues endpoint

### DIFF
--- a/webiu-server/src/project/dto/org-repo-query.dto.ts
+++ b/webiu-server/src/project/dto/org-repo-query.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, Matches, MaxLength } from 'class-validator';
+
+export class OrgRepoQueryDto {
+  @IsNotEmpty({ message: 'Organization name is required' })
+  @Matches(/^[a-zA-Z0-9_-]+$/, {
+    message:
+      'Organization name can only contain letters, numbers, hyphens, and underscores',
+  })
+  @MaxLength(39, { message: 'Organization name cannot exceed 39 characters' })
+  org: string;
+
+  @IsNotEmpty({ message: 'Repository name is required' })
+  @Matches(/^[a-zA-Z0-9._-]+$/, {
+    message:
+      'Repository name can only contain letters, numbers, hyphens, underscores, and dots',
+  })
+  @MaxLength(100, { message: 'Repository name cannot exceed 100 characters' })
+  repo: string;
+}

--- a/webiu-server/src/project/project.controller.spec.ts
+++ b/webiu-server/src/project/project.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProjectController, IssuesController } from './project.controller';
 import { ProjectService } from './project.service';
+import { OrgRepoQueryDto } from './dto/org-repo-query.dto';
 
 describe('ProjectController', () => {
   let controller: ProjectController;
@@ -75,7 +76,8 @@ describe('IssuesController', () => {
       const mockResult = { issues: 5, pullRequests: 3 };
       mockProjectService.getIssuesAndPr.mockResolvedValue(mockResult);
 
-      const result = await controller.getIssuesAndPr('c2siorg', 'repo1');
+      const dto: OrgRepoQueryDto = { org: 'c2siorg', repo: 'repo1' };
+      const result = await controller.getIssuesAndPr(dto);
 
       expect(result).toEqual(mockResult);
       expect(mockProjectService.getIssuesAndPr).toHaveBeenCalledWith(

--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Query, Header } from '@nestjs/common';
 import { ProjectService } from './project.service';
+import { OrgRepoQueryDto } from './dto/org-repo-query.dto';
 
 @Controller('api/projects')
 export class ProjectController {
@@ -18,7 +19,7 @@ export class IssuesController {
 
   @Get('issuesAndPr')
   @Header('Cache-Control', 'public, max-age=300')
-  async getIssuesAndPr(@Query('org') org: string, @Query('repo') repo: string) {
+  async getIssuesAndPr(@Query() { org, repo }: OrgRepoQueryDto) {
     return this.projectService.getIssuesAndPr(org, repo);
   }
 }


### PR DESCRIPTION
## Summary

* Added `OrgRepoQueryDto` with `@IsNotEmpty`, `@Matches`, and `@MaxLength` validators for `org` and `repo` query parameters
* Updated `IssuesController.getIssuesAndPr` to use `@Query() dto: OrgRepoQueryDto`
* Updated controller spec to pass the DTO object
Fixes #312 


## Test Plan

* Backend: `npm run lint` — all files pass
* Backend: `npm test` — 58/58 tests pass
* Invalid input: `GET /api/issues/issuesAndPr` (missing params) → 400 Bad Request
* Invalid input: `GET /api/issues/issuesAndPr?org=bad!char&repo=x` → 400 Bad Request
* Valid input: `GET /api/issues/issuesAndPr?org=c2siorg&repo=Webiu` → 200 OK
**PR Title**
fix: add query param validation to issues endpoint


## Summary

* Added `OrgRepoQueryDto` with `@IsNotEmpty`, `@Matches`, and `@MaxLength` validators for `org` and `repo` query parameters
* Updated `IssuesController.getIssuesAndPr` to use `@Query() dto: OrgRepoQueryDto`
* Updated controller spec to pass the DTO object


## Test Plan
* Invalid input: `GET /api/issues/issuesAndPr` (missing params) → 400 Bad Request
* Invalid input: `GET /api/issues/issuesAndPr?org=bad!char&repo=x` → 400 Bad Request
* Valid input: `GET /api/issues/issuesAndPr?org=c2siorg&repo=Webiu` → 200 OK
<img width="961" height="230" alt="Screenshot 2026-02-21 at 4 32 02 AM" src="https://github.com/user-attachments/assets/6339a18e-43a2-410c-b80d-8eb0a5660182" />

