### PR TITLE
fix: add @Matches validation to BatchSocialDto usernames

### DIFF
--- a/webiu-server/src/user/dto/batch-social.dto.ts
+++ b/webiu-server/src/user/dto/batch-social.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   ArrayNotEmpty,
   ArrayMaxSize,
+  Matches,
 } from 'class-validator';
 
 export class BatchSocialDto {
@@ -10,5 +11,10 @@ export class BatchSocialDto {
   @ArrayNotEmpty()
   @ArrayMaxSize(500)
   @IsString({ each: true })
+  @Matches(/^[a-zA-Z0-9_-]+$/, {
+    each: true,
+    message:
+      'Each username can only contain letters, numbers, hyphens, and underscores',
+  })
   usernames: string[];
 }


### PR DESCRIPTION
Fixes #315 
## Summary

* Added `@Matches` regex decorator to the `usernames` field in `BatchSocialDto`
* Rejects any username containing characters outside `[a-zA-Z0-9_-]` with a 400 Bad Request before the request reaches the GitHub API


## Test Plan

* Invalid: `POST /api/user/batch-social` with `{"usernames":["bad user!"]}` → 400
* Valid: `POST /api/user/batch-social` with `{"usernames":["torvalds","gaearon"]}` → 200
