### PR TITLE
fix: remove debug console.log from navbar logout

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -73,7 +73,6 @@ export class NavbarComponent implements OnInit {
   logout(): void {
     this.isLoggedIn = false;
     this.user = null;
-    console.log('Logged out');
   }
 
   loginWithGoogle(): void {


### PR DESCRIPTION
## Summary

* Removed leftover `console.log('Logged out')` from `NavbarComponent.logout()` to clean up debug output and keep production console free of unnecessary logs
