### PR TITLE
fix: equalise contributor card heights across grid rows

### DIFF
--- a/webiu-ui/src/app/components/profile-card/profile-card.component.scss
+++ b/webiu-ui/src/app/components/profile-card/profile-card.component.scss
@@ -7,6 +7,7 @@
   width: 100%;
   max-width: 350px;
   min-height: 300px;
+  height: 100%;
   align-items: center;
   justify-content: center;
   flex-direction: column;

--- a/webiu-ui/src/app/page/contributors/contributors.component.scss
+++ b/webiu-ui/src/app/page/contributors/contributors.component.scss
@@ -244,6 +244,7 @@
       flex: 0 0 auto;
       width: 280px;
       max-width: 100%;
+      display: flex;
     }
 
     .contributor-card {


### PR DESCRIPTION
## Summary

* Added `height: 100%` to `.profile-box` in `profile-card.component.scss` so the card fills its flex container height
* Added `display: flex` to `app-profile-card` in `contributors.component.scss` so the host element participates in flexbox stretching
Fixes #333 

## Test Plan
* Manual check: `/contributors` page — all cards in each row render at equal height

**Before**
<img width="1470" height="752" alt="image" src="https://github.com/user-attachments/assets/bcdaa83a-7d13-441b-a9d7-bc525ddfc2f0" />

**After**
<img width="1469" height="835" alt="image" src="https://github.com/user-attachments/assets/40c522ff-40c7-49d4-957c-73f0ba17f535" />

