### PR TITLE
fix: prevent language badge overlap with toggle button on project card

### DIFF
--- a/webiu-ui/src/app/components/projects-card/projects-card.component.scss
+++ b/webiu-ui/src/app/components/projects-card/projects-card.component.scss
@@ -63,7 +63,7 @@
       gap: 10px;
 
       span {
-        padding-right: 25px;
+        margin-right: 50px;
         display: flex;
         gap: 10px;
 


### PR DESCRIPTION
## Summary

* The language badge (color dot and language name) in the top-right of each project card was overlapping the absolutely positioned chevron toggle button
* Replaced `padding-right: 25px` with `margin-right: 50px` on the language badge `span` so the element itself shifts clear of the button instead of only pushing its internal content
**Before**
<img width="920" height="462" alt="Screenshot 2026-02-21 at 11 24 19 AM" src="https://github.com/user-attachments/assets/d9c4b69e-1593-40af-934e-73cfefa6106e" />
**After**
<img width="934" height="410" alt="image" src="https://github.com/user-attachments/assets/c0bab882-0f5c-4436-aeb4-748ffa051383" />

