### PR TITLE
feat: add endpoint to auto-detect tech stack for a given repository

### DIFF
--- a/webiu-server/src/project/project.controller.spec.ts
+++ b/webiu-server/src/project/project.controller.spec.ts
@@ -8,6 +8,11 @@ describe('ProjectController', () => {
   const mockProjectService = {
     getAllProjects: jest.fn(),
     getIssuesAndPr: jest.fn(),
+    searchProjects: jest.fn(),
+    getProjectByName: jest.fn(),
+    getRepoTechStack: jest.fn(),
+    getProjectInsights: jest.fn(),
+    getProjectContributors: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -46,6 +51,18 @@ describe('ProjectController', () => {
 
       expect(result).toEqual(mockResult);
       expect(mockProjectService.getAllProjects).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  describe('getRepoTechStack', () => {
+    it('should return tech stack from service', async () => {
+      const mockResult = { languages: ['TypeScript', 'JavaScript'] };
+      mockProjectService.getRepoTechStack.mockResolvedValue(mockResult);
+
+      const result = await controller.getRepoTechStack('Webiu');
+
+      expect(result).toEqual(mockResult);
+      expect(mockProjectService.getRepoTechStack).toHaveBeenCalledWith('Webiu');
     });
   });
 });

--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -43,6 +43,12 @@ export class ProjectController {
     return this.projectService.searchProjects(query, pageNum, limitNum);
   }
 
+  @Get('tech-stack/:repo')
+  @Header('Cache-Control', 'public, max-age=300')
+  async getRepoTechStack(@Param('repo') repo: string) {
+    return this.projectService.getRepoTechStack(repo);
+  }
+
   /**
    * GET /api/v1/projects/:name
    * Returns metadata and tech stack for a specific project.

--- a/webiu-server/src/project/project.service.spec.ts
+++ b/webiu-server/src/project/project.service.spec.ts
@@ -158,6 +158,42 @@ describe('ProjectService', () => {
     });
   });
 
+  describe('getRepoTechStack', () => {
+    it('should return languages array', async () => {
+      mockGithubService.getRepoLanguages.mockResolvedValue({
+        TypeScript: 12345,
+        JavaScript: 6789,
+      });
+
+      const result = await service.getRepoTechStack('repo1');
+      expect(result).toEqual({ languages: ['TypeScript', 'JavaScript'] });
+    });
+
+    it('should cache the result', async () => {
+      mockGithubService.getRepoLanguages.mockResolvedValue({ TypeScript: 1 });
+
+      await service.getRepoTechStack('repo1');
+      await service.getRepoTechStack('repo1');
+
+      expect(mockGithubService.getRepoLanguages).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw BadRequestException when repoName is empty', async () => {
+      await expect(service.getRepoTechStack('')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw InternalServerErrorException on API error', async () => {
+      mockGithubService.getRepoLanguages.mockRejectedValue(
+        new Error('API error'),
+      );
+      await expect(service.getRepoTechStack('repo1')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
   describe('getProjectByName', () => {
     it('should return enriched project metadata', async () => {
       mockGithubService.getRepo.mockResolvedValue({

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -62,6 +62,29 @@ export class ProjectService {
     }
   }
 
+  async getRepoTechStack(repoName: string) {
+    if (!repoName) {
+      throw new BadRequestException('Repository name is required');
+    }
+
+    const cacheKey = `tech_stack_${repoName}`;
+    const cached = this.cacheService.get(cacheKey);
+    if (cached) return cached;
+
+    try {
+      const langMap = await this.githubService.getRepoLanguages(repoName);
+      const result = { languages: Object.keys(langMap) };
+      this.cacheService.set(cacheKey, result, CACHE_TTL);
+      return result;
+    } catch (error) {
+      this.logger.error(
+        'Error fetching tech stack:',
+        error.response?.data || error.message,
+      );
+      throw new InternalServerErrorException('Failed to fetch tech stack');
+    }
+  }
+
   async getIssuesAndPr(org: string, repo: string) {
     if (!org || !repo) {
       throw new BadRequestException('Organization and repository are required');

--- a/webiu-ui/src/app/components/projects-card/projects-card.component.html
+++ b/webiu-ui/src/app/components/projects-card/projects-card.component.html
@@ -128,6 +128,12 @@
         <p><strong> Created at: </strong> {{ createdAt | date: "medium" }}</p>
         <p><strong> Updated at: </strong> {{ updatedAt | date: "medium" }}</p>
       </div>
+      @for (lang of languages; track lang) {
+        <div class="projects__card__tag projects__card__lang-tag">
+          <span class="lang-dot" [style.background-color]="getLanguageColor(lang)"></span>
+          {{ lang }}
+        </div>
+      }
     </div>
   }
 </div>

--- a/webiu-ui/src/app/components/projects-card/projects-card.component.scss
+++ b/webiu-ui/src/app/components/projects-card/projects-card.component.scss
@@ -266,6 +266,21 @@
         padding: 4px 6px;
         border-radius: 20px;
       }
+
+      .projects__card__lang-tag {
+        border-color: #2b7489;
+        background-color: rgba(43, 116, 137, 0.12);
+        display: flex;
+        align-items: center;
+        gap: 5px;
+
+        .lang-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+      }
     }
 
     .projects__card__details {

--- a/webiu-ui/src/app/components/projects-card/projects-card.component.ts
+++ b/webiu-ui/src/app/components/projects-card/projects-card.component.ts
@@ -28,6 +28,8 @@ export class ProjectsCardComponent implements OnInit {
   issueCount = 0;
   pullRequestCount = 0;
   initialized = false;
+  languages: string[] = [];
+  techStackLoaded = false;
 
   private http = inject(HttpClient);
 
@@ -50,14 +52,30 @@ export class ProjectsCardComponent implements OnInit {
         error: (error) => {
           console.error(`Error fetching issues and PRs for ${this.repo}: `, error);
           this.initialized = true;
-        }
+        },
       });
+  }
+
+  fetchTechStack(): void {
+    const apiUrl = `${environment.serverUrl}/api/v1/projects/tech-stack/${this.repo}`;
+    this.http.get<{ languages: string[] }>(apiUrl).subscribe({
+      next: (data) => {
+        this.languages = data.languages ?? [];
+        this.techStackLoaded = true;
+      },
+      error: (error) => {
+        console.error('Failed to fetch tech stack:', error);
+      },
+    });
   }
 
   public detailsVisible = false;
 
   toggleDetails() {
     this.detailsVisible = !this.detailsVisible;
+    if (this.detailsVisible && !this.techStackLoaded) {
+      this.fetchTechStack();
+    }
   }
 
   get truncatedDescription(): string {
@@ -69,7 +87,7 @@ export class ProjectsCardComponent implements OnInit {
       : this.description;
   }
 
-  getLanguageColor(): string {
+  getLanguageColor(lang?: string): string {
     const languageColors: Record<string, string> = {
       Python: '#3572A5',
       JavaScript: '#F1E05A',
@@ -81,6 +99,6 @@ export class ProjectsCardComponent implements OnInit {
       Default: '#607466',
     };
 
-    return languageColors[this.language] || languageColors['Default'];
+    return languageColors[lang ?? this.language] || languageColors['Default'];
   }
 }


### PR DESCRIPTION
## Summary

* Added `getRepoLanguages(repoName)` to `GithubService` to call GitHub `/repos/{org}/{repo}/languages` and cache the result
* Added `getRepoTechStack(repoName)` to `ProjectService` to validate input, handle caching, and throw `InternalServerErrorException` on failure
* Exposed `GET /api/projects/tech-stack/:repo` in `ProjectController` with `Cache-Control: public, max-age=300`
* Added unit tests across controller, service, and GitHub layers (66 tests total, all passing)

Fixes #341 

## Test Plan

* `curl http://localhost:5050/api/projects/tech-stack/Webiu` returns `{ "languages": [...] }`
* `npm test` passes with 66 tests
* Second request results in a cache hit with no additional GitHub API call
<img width="978" height="246" alt="Screenshot 2026-02-21 at 12 50 30 PM" src="https://github.com/user-attachments/assets/3201dcb2-a65b-4c2c-abfa-2da9927a16b1" />
<img width="1084" height="650" alt="image" src="https://github.com/user-attachments/assets/b8d3d0e9-b901-4043-823d-05c1b3a52dca" />

