### PR TITLE
fix(server): remove non-existent test/ dir from eslint glob

### DIFF
--- a/webiu-server/package.json
+++ b/webiu-server/package.json
@@ -10,7 +10,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint \"{src,apps,libs}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
## Description

The default NestJS scaffold generates a `lint` script that includes the `test/` directory in its ESLint glob:

```
"lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
```

This project has no `test/` directory — all `*.spec.ts` files live inside `src/` alongside their source files. When the Husky pre-commit hook called `npm run lint` via `lint-staged`, ESLint attempted to resolve `test/**/*.ts` which matched nothing, leading to potential exit-code errors that could block commits unnecessarily.

**Change made:**

- Removed `test` from the ESLint glob in `webiu-server/package.json`:
  ```
  Before: "eslint \"{src,apps,libs,test}/**/*.ts\" --fix"
  After:  "eslint \"{src,apps,libs}/**/*.ts\" --fix"
  ```

**Files changed:**

- `webiu-server/package.json`

Fixes #293

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `npm run lint` in `webiu-server/` — exits cleanly with no errors.
- Ran `npm test` in `webiu-server/` — all 58 existing tests pass.
- Staged a `.ts` file and ran `git commit` to confirm the Husky pre-commit hook completes without error.

- [x] `npm run lint` passes (webiu-server)
- [x] All 58 unit tests pass (`npm test`)
- [x] Husky pre-commit hook completes cleanly on a staged `.ts` change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
