### PR TITLE
fix: return HTTP 200 for login POST endpoint

### DIFF
--- a/webiu-server/src/auth/auth.controller.ts
+++ b/webiu-server/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Query } from '@nestjs/common';
+import { Controller, Post, Get, Body, Query, HttpCode } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -13,6 +13,7 @@ export class AuthController {
   }
 
   @Post('login')
+  @HttpCode(200)
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
   }


### PR DESCRIPTION
Closes #359

## Description

NestJS defaults to HTTP 201 (Created) for @Post() routes.

The login endpoint does not create a new resource and should return HTTP 200 (OK) instead.

This PR adds @HttpCode(200) to the login endpoint to align with correct REST semantics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified POST /login now returns HTTP 200 instead of 201.
- No changes to business logic.