### PR TITLE
fix:JwtAuthGuard uses weak token extraction

### DIFF
--- a/webiu-server/src/auth/guards/jwt-auth.guard.ts
+++ b/webiu-server/src/auth/guards/jwt-auth.guard.ts
@@ -14,11 +14,11 @@ export class JwtAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const authHeader = request.headers.authorization;
 
-    if (!authHeader) {
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
       throw new UnauthorizedException('Not authorized');
     }
 
-    const token = authHeader.replace('Bearer ', '');
+    const token = authHeader.slice(7);
 
     try {
       const decoded = this.jwtService.verify(token);


### PR DESCRIPTION
## Description

 ` if (!authHeader || !authHeader.startsWith('Bearer '))`
`authHeader.slice(7);`

Fixes #369


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
