### PR TITLE
fix(ui): align login dropdown below login button

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.html
+++ b/webiu-ui/src/app/components/navbar/navbar.component.html
@@ -129,6 +129,7 @@
       <img src="../../../assets/gsoc.svg" alt="GSoC Icon" class="menu-icon" />
       <p>GSoC 26</p>
     </div>
+    <div class="login-wrapper">
     <button
       class="navbar__menu__items Login_Logout"
       type="button"
@@ -165,6 +166,7 @@
         </button>
       </div>
     }
+    </div>
   </div>
 
   <div class="navbar__right-actions">

--- a/webiu-ui/src/app/components/navbar/navbar.component.scss
+++ b/webiu-ui/src/app/components/navbar/navbar.component.scss
@@ -300,10 +300,17 @@
 /* ────────────────────────────────────────────────────────
    Login options (desktop dropdown — outside .open)
    ──────────────────────────────────────────────────────── */
+.login-wrapper {
+  position: relative;   
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+
 .login-options {
   position: absolute;
-  top: 100%;
-  right: 20px;
+  top: 164%;
+  right: 0;  
   background: var(--navbar-bg);
   border: 1px solid var(--border-color);
   border-radius: 8px;


### PR DESCRIPTION



## Description


This PR fixes the issue where the login dropdown appeared aligned toward the far right of the navbar instead of directly below the Login button.

<img width="1600" height="1035" alt="image" src="https://github.com/user-attachments/assets/f7d71dda-3c17-41ec-b3ed-20a181dc8b78" />


https://github.com/user-attachments/assets/43563e85-2476-45c8-87b1-5cc80e1fbcce






Closes #439

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Manually tested on multiple desktop screen sizes.
- Verified correct alignment at different viewport widths.
- Frontend and backend lint checks pass.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
