### PR TITLE
fix(ui): replace direct GitHub API calls in Community page with backend batch-social endpoint

### DIFF
--- a/webiu-ui/src/app/page/community/community.component.ts
+++ b/webiu-ui/src/app/page/community/community.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { NavbarComponent } from '../../components/navbar/navbar.component';
 import { Media, socialMedia } from '../../common/data/media';
 import { Contributor } from '../../common/data/contributor';
-import { CommmonUtilService } from '../../common/service/commmon-util.service';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { ProfileCardComponent } from '../../components/profile-card/profile-card.component';
@@ -25,7 +24,6 @@ import { BackToTopComponent } from '../../components/back-to-top/back-to-top.com
   styleUrls: ['./community.component.scss'],
 })
 export class CommunityComponent implements OnInit {
-  private commonUtil = inject(CommmonUtilService);
   private http = inject(HttpClient);
   icons: Media[] = socialMedia;
   users: Contributor[] = [];
@@ -37,12 +35,9 @@ export class CommunityComponent implements OnInit {
 
   getTopContributors() {
     this.http
-      .get<
-        Contributor[]
-      >(`${environment.serverUrl}/api/contributor/contributors`)
+      .get<Contributor[]>(`${environment.serverUrl}/api/contributor/contributors`)
       .subscribe({
         next: (res) => {
-          // Sort by contributions in descending order, take top 9
           const sorted = (res || []).sort(
             (a, b) => b.contributions - a.contributions,
           );
@@ -50,7 +45,6 @@ export class CommunityComponent implements OnInit {
           this.fetchFollowerData();
         },
         error: () => {
-          console.error('Error fetching contributors');
           this.users = [];
           this.isLoading = false;
         },
@@ -58,31 +52,31 @@ export class CommunityComponent implements OnInit {
   }
 
   fetchFollowerData() {
-    let requestsCompleted = 0;
     if (this.users.length === 0) {
       this.isLoading = false;
       return;
     }
 
-    const checkCompletion = () => {
-      requestsCompleted++;
-      if (requestsCompleted === this.users.length) {
-        this.isLoading = false;
-      }
-    };
+    const usernames = this.users.map((u) => u.login);
 
-    this.users.forEach((profile) => {
-      this.http.get(`https://api.github.com/users/${profile.login}`).subscribe({
-        next: (data: any) => {
-          profile.followers = data.followers;
-          profile.following = data.following;
-          checkCompletion();
+    this.http
+      .post<Record<string, { followers: number; following: number }>>(
+        `${environment.serverUrl}/api/user/batch-social`,
+        { usernames },
+      )
+      .subscribe({
+        next: (data) => {
+          this.users.forEach((user) => {
+            const social = data[user.login];
+            user.followers = social?.followers ?? 0;
+            user.following = social?.following ?? 0;
+          });
+          this.isLoading = false;
         },
         error: () => {
-          console.error(`Error fetching followers for ${profile.login}`);
-          checkCompletion();
+          // Show contributors without social counts rather than failing entirely
+          this.isLoading = false;
         },
       });
-    });
   }
 }


### PR DESCRIPTION
# Pull Request Descriptions

---

##  fix/community-cors-fetch · Closes #403

The Community page fetched follower/following counts by making individual unauthenticated requests directly to `https://api.github.com/users/<login>` from the browser. These calls hit CORS restrictions and GitHub's 60 req/hour unauthenticated rate limit, causing follower/following counts to be missing or incorrect on the Community page.

Replace the per-user direct GitHub API calls with a single `POST /api/user/batch-social` request to the backend, which uses the authenticated token, handles batching internally, and is already cached. This is the same approach `ContributorsComponent` already uses. On failure the page degrades gracefully — contributors are shown without social counts rather than breaking entirely.

Closes #403

## Description

`CommunityComponent.fetchFollowerData()` iterated over the top 8 contributors and fired one `this.http.get('https://api.github.com/users/<login>')` per user directly from the browser. The backend already exposes `POST /api/user/batch-social` which accepts an array of usernames and returns follower/following data using the authenticated `GITHUB_ACCESS_TOKEN` — the `ContributorsComponent` uses this exact endpoint. The Community page was never updated to follow the same pattern.

Also removed the now-unused `CommmonUtilService` injection.

Fixes #403

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Start backend (`npm start`) and frontend (`ng serve`). Open `http://localhost:4200/community` with DevTools → Network → Fetch/XHR filter active and hard-refresh.

**Before (master):** 8 individual requests to `api.github.com/users/<login>` visible in Network tab; some fail with CORS or 429 errors; follower/following counts on cards show 0 or are missing.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/636331ea-591a-4726-a1bc-484a1562e174" />
**After (fix branch):** A single `POST localhost:5050/api/user/batch-social`; zero requests to `api.github.com`; follower/following counts populated correctly on all cards.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6a4bb4aa-0228-49f7-96d5-27f62ce639d2" />
Kill the backend and reload — page still renders the contributor list without social counts (graceful degradation).

- [x] No direct browser requests to `api.github.com` on the Community page
- [x] Follower/following counts populated correctly via backend
- [x] Graceful degradation when `batch-social` fails
- [x] `npm run lint` passes (webiu-ui)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---