### PR TITLE
feat(navbar): add Opportunities under Community (fixes #427)

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.html
+++ b/webiu-ui/src/app/components/navbar/navbar.component.html
@@ -101,19 +101,50 @@
       <img src="../../../assets/contributors.svg" alt="Contributors Icon" class="menu-icon" />
       <p>Contributors</p>
     </div>
-    <div
-      class="navbar__menu__items"
-      routerLink="/community"
-      [class.active]="isRouteActive('/community')"
-      (click)="navigateTo('/community')"
-      (keydown.enter)="navigateTo('/community')"
-      (keydown.space)="navigateTo('/community'); $event.preventDefault()"
-      tabindex="0"
-      role="link"
-      [attr.aria-label]="'Community'"
-    >
-      <img src="../../../assets/community.svg" alt="Community Icon" class="menu-icon" />
-      <p>Community</p>
+    <div class="dropdown-container">
+      <div
+        class="navbar__menu__items community-toggle"
+        [class.active]="isRouteActive('/community')"
+        (click)="toggleCommunityDropdown(); $event.stopPropagation()"
+        (keydown.enter)="toggleCommunityDropdown(); $event.stopPropagation()"
+        (keydown.space)="toggleCommunityDropdown(); $event.stopPropagation(); $event.preventDefault()"
+        tabindex="0"
+        role="button"
+        [attr.aria-label]="'Community Dropdown'"
+      >
+        <img src="../../../assets/community.svg" alt="Community Icon" class="menu-icon" />
+        <p>Community</p>
+        <span class="dropdown-arrow" [class.open]="isCommunityDropdownOpen">▼</span>
+      </div>
+
+      @if (isCommunityDropdownOpen) {
+        <div class="dropdown-menu community-dropdown" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()" tabindex="-1">
+          <div
+            class="dropdown-item"
+            routerLink="/community"
+            [class.active]="currentRoute === '/community'"
+            (click)="navigateTo('/community')"
+            (keydown.enter)="navigateTo('/community')"
+            (keydown.space)="navigateTo('/community'); $event.preventDefault()"
+            tabindex="0"
+            role="link"
+          >
+            <p>Community</p>
+          </div>
+          <div
+            class="dropdown-item"
+            routerLink="/opportunities"
+            [class.active]="currentRoute === '/opportunities'"
+            (click)="navigateTo('/opportunities')"
+            (keydown.enter)="navigateTo('/opportunities')"
+            (keydown.space)="navigateTo('/opportunities'); $event.preventDefault()"
+            tabindex="0"
+            role="link"
+          >
+            <p>Opportunities</p>
+          </div>
+        </div>
+      }
     </div>
     <div
       class="navbar__menu__items"

--- a/webiu-ui/src/app/components/navbar/navbar.component.scss
+++ b/webiu-ui/src/app/components/navbar/navbar.component.scss
@@ -46,6 +46,7 @@
   justify-content: center;
   align-items: center;
   gap: 5px;
+  margin-left: auto;
 
   /* hide sidebar header on desktop */
   .sidebar-header {
@@ -103,6 +104,87 @@
 
     img {
       filter: invert(1);
+    }
+  }
+
+  /* Dropdown container */
+  .dropdown-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .community-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .dropdown-arrow {
+    font-size: 10px;
+    transition: transform 0.3s ease;
+    margin-left: 2px;
+    color: var(--navbar-p);
+    pointer-events: none;
+
+    &.open {
+      transform: rotate(180deg);
+    }
+  }
+
+  .navbar__menu__items:hover .dropdown-arrow {
+    color: #fff;
+  }
+
+  .navbar__menu__items.active .dropdown-arrow {
+    color: #fff;
+  }
+
+  /* Dropdown menu (desktop) */
+  .dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    margin-top: 10px;
+    background: var(--navbar-bg);
+    border: 1px solid var(--border-color, #e6e6e6);
+    border-radius: 8px;
+    box-shadow: 0px 4px 24px 0px rgba(0, 0, 0, 0.15);
+    width: 200px;
+    z-index: 1000;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    .dropdown-item {
+      padding: 10px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-align: left;
+      
+      p {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--navbar-p);
+      }
+
+      &:hover {
+        background: var(--blue, #2980b9);
+        p {
+          color: #fff;
+        }
+      }
+
+      &.active {
+        background: var(--blue, #3498db);
+        p {
+          color: #fff;
+        }
+      }
     }
   }
 }
@@ -231,6 +313,77 @@
 
     .login-logout-icon {
       display: none !important;
+    }
+  }
+
+  /* Dropdown overrides for mobile sidebar */
+  .dropdown-container {
+    width: 100%;
+    align-items: stretch;
+    border-bottom: 1px solid var(--sidebar-border, #e6e6e6);
+  }
+
+  .community-toggle {
+    border-bottom: none !important;
+    justify-content: space-between !important;
+    padding-right: 24px;
+    cursor: pointer;
+  }
+
+  .dropdown-arrow {
+    margin-left: auto;
+    font-size: 14px;
+    transition: transform 0.2s ease;
+    opacity: 0.7;
+
+    &.open {
+      transform: rotate(180deg);
+    }
+  }
+
+  .dropdown-menu {
+    position: static;
+    width: 100%;
+    box-shadow: none;
+    border: none;
+    padding: 0 0 16px 48px;
+    margin-top: 0;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    animation: none; /* Disable any absolute positioning animations */
+
+    .dropdown-item {
+      border-radius: 0;
+      padding: 12px 0;
+      border-bottom: none;
+      background: transparent;
+      width: 100%;
+
+      p {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--navbar-p);
+        margin: 0;
+      }
+
+      &:hover {
+        background: transparent;
+        p {
+          color: var(--blue, #0066ff);
+        }
+      }
+      
+      &.active {
+        background: transparent;
+        border-left: none;
+        padding-left: 0;
+        p {
+          color: var(--blue, #0066ff);
+          font-weight: 600;
+        }
+      }
     }
   }
 

--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -21,6 +21,7 @@ export class NavbarComponent implements OnInit {
   isSunVisible = true;
   isLoggedIn = false;
   showLoginOptions = false;
+  isCommunityDropdownOpen = false;
   user: any;
   currentRoute = '/';
 
@@ -35,6 +36,7 @@ export class NavbarComponent implements OnInit {
       .subscribe((event: NavigationEnd) => {
         this.currentRoute = event.url;
         this.isMenuOpen = false;
+        this.isCommunityDropdownOpen = false;
       });
 
     if (isPlatformBrowser(this.platformId)) {
@@ -59,15 +61,33 @@ export class NavbarComponent implements OnInit {
       this.logout();
     } else {
       this.showLoginOptions = !this.showLoginOptions;
+      if (this.showLoginOptions) {
+        this.isCommunityDropdownOpen = false;
+      }
     }
+  }
+
+  toggleCommunityDropdown(): void {
+    this.isCommunityDropdownOpen = !this.isCommunityDropdownOpen;
+    if (this.isCommunityDropdownOpen) {
+      this.showLoginOptions = false;
+    }
+  }
+
+  closeCommunityDropdown(): void {
+    this.isCommunityDropdownOpen = false;
   }
 
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
+    if (!this.isMenuOpen) {
+      this.isCommunityDropdownOpen = false;
+    }
   }
 
   closeMenu(): void {
     this.isMenuOpen = false;
+    this.isCommunityDropdownOpen = false;
   }
 
   toggleTheme(): void {
@@ -112,6 +132,8 @@ export class NavbarComponent implements OnInit {
     const loginButton = document.querySelector('.Login_Logout');
     const navbarMenu = document.querySelector('#navbarMenu');
     const navigationButtons = document.querySelector('.navigation__buttons');
+    const communityDropdown = document.querySelector('.community-dropdown');
+    const communityButton = document.querySelector('.community-toggle');
 
     // Handle login options closing
     if (
@@ -120,6 +142,15 @@ export class NavbarComponent implements OnInit {
       !loginButton?.contains(event.target as Node)
     ) {
       this.showLoginOptions = false;
+    }
+
+    // Handle community dropdown closing
+    if (
+      this.isCommunityDropdownOpen &&
+      !communityDropdown?.contains(event.target as Node) &&
+      !communityButton?.contains(event.target as Node)
+    ) {
+      this.isCommunityDropdownOpen = false;
     }
 
     // Handle menu closing when clicking outside (but not on the toggle button)
@@ -135,6 +166,9 @@ export class NavbarComponent implements OnInit {
 
   isRouteActive(route: string): boolean {
     if (route === '/projects' && this.currentRoute.startsWith('/project')) {
+      return true;
+    }
+    if (route === '/community' && (this.currentRoute === '/community' || this.currentRoute === '/opportunities')) {
       return true;
     }
     return this.currentRoute === route;


### PR DESCRIPTION
## Summary

Expose the existing `/opportunities` page via the **Community** dropdown in the main navbar to improve discoverability without adding a new top-level item.

## Changes

* Added **Opportunities** under the Community dropdown in the navbar
* Linked to `/opportunities` using existing routing structure
* Preserved current navbar layout and styling

## Notes

The Opportunities page already exists and was accessible via direct URL only. This integrates it into primary navigation (fixes #427).

While reviewing related sections, noticed the GSoC’24 page has missing project data. Happy to restore this in a **separate PR** if desired.
<img width="1746" height="1062" alt="Screenshot 2026-02-25 at 11 15 47 PM" src="https://github.com/user-attachments/assets/a8049eec-0077-48aa-8e5c-0988e4f2ad2f" />

