### PR TITLE
fix: resolve three backend API bugs

### DIFF
--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -16,7 +16,14 @@ GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_REDIRECT_URI=http://localhost:4200/auth/google/callback
 
-# Email (Gmail SMTP)
+# ==============================
+# Backend (used in verification email links)
+# ==============================
+BACKEND_BASE_URL=http://localhost:5050
+
+# ==============================
+# Email Service (Gmail / Nodemailer)
+# ==============================
 GMAIL_USER=your_gmail_address@gmail.com
 GMAIL_PASSWORD=your_gmail_app_password
 

--- a/webiu-server/src/email/email.service.ts
+++ b/webiu-server/src/email/email.service.ts
@@ -22,16 +22,16 @@ export class EmailService {
     email: string,
     verificationToken: string,
   ): Promise<void> {
-    const frontendBaseUrl = this.configService.get<string>(
-      'FRONTEND_BASE_URL',
-      'http://localhost:4200',
+    const backendBaseUrl = this.configService.get<string>(
+      'BACKEND_BASE_URL',
+      `http://localhost:${this.configService.get<number>('PORT', 5050)}`,
     );
 
     const mailOptions = {
       from: `"Webiu" <${this.configService.get<string>('GMAIL_USER')}>`,
       to: email,
       subject: 'Verify Your Email Address',
-      html: getVerifyEmailTemplate(frontendBaseUrl, verificationToken),
+      html: getVerifyEmailTemplate(backendBaseUrl, verificationToken),
     };
 
     try {

--- a/webiu-server/src/email/templates/verify-email.template.ts
+++ b/webiu-server/src/email/templates/verify-email.template.ts
@@ -1,5 +1,5 @@
 export const getVerifyEmailTemplate = (
-  frontendBaseUrl: string,
+  backendBaseUrl: string,
   verificationToken: string,
 ): string => `
   <div style="font-family: Arial, sans-serif; line-height: 1.6;">
@@ -10,9 +10,9 @@ export const getVerifyEmailTemplate = (
     <p>
       Click the link below to verify your email:
     </p>
-    <a 
-      href="${frontendBaseUrl}/api/v1/auth/verify-email?token=${verificationToken}" 
-      style="display: inline-block; padding: 10px 20px; color: #fff; background-color: #3498db; text-decoration: none; border-radius: 5px; font-weight: bold;"
+    <a
+      href="${backendBaseUrl}/api/v1/auth/verify-email?token=${verificationToken}"
+      style="display: inline-block; padding: 10px 20px; color: #fff; background-color: #007BFF; text-decoration: none; border-radius: 5px; font-weight: bold;"
     >
       Verify Email
     </a>

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -251,7 +251,7 @@ export class GithubService {
     if (cached) return cached;
 
     const pulls = await this.fetchAllPages(
-      `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls`,
+      `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls?state=all`,
     );
     this.cacheService.set(cacheKey, pulls);
     return pulls;

--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -5,7 +5,7 @@ import { ProjectService } from './project.service';
 export class ProjectController {
   constructor(private projectService: ProjectService) {}
 
-  @Get('projects')
+  @Get()
   @Header('Cache-Control', 'public, max-age=300')
   async getAllProjects(
     @Query('page') page: string = '1',

--- a/webiu-ui/src/app/services/project-cache.service.ts
+++ b/webiu-ui/src/app/services/project-cache.service.ts
@@ -19,7 +19,7 @@ export class ProjectCacheService {
    */
   getProjects(page = 1, limit = 10): Observable<ProjectResponse> {
     return this.http.get<ProjectResponse>(
-      `${environment.serverUrl}/api/projects/projects?page=${page}&limit=${limit}`,
+      `${environment.serverUrl}/api/projects?page=${page}&limit=${limit}`,
     );
   }
 


### PR DESCRIPTION
## Description

This PR fixes three critical backend API bugs that produce incorrect data or broken functionality.

## Changes Made

### 1. Fix Duplicated Route Path in Project Controller

**Issue:** The project controller had duplicated route segments, resulting in routes like `/api/projects/projects` instead of `/api/projects`.

**File:** `webiu-server/src/project/project.controller.ts`

- Changed `@Get('projects')` to `@Get()` on the `getAllProjects` endpoint
- The route is now correctly: `@Controller('api/projects')` + `@Get()` = `/api/projects`

### 2. Fix `getRepoPulls` to Fetch All Pull Requests

**Issue:** The GitHub API endpoint for fetching pull requests was missing the `?state=all` parameter, causing it to only return currently open PRs.

**File:** `webiu-server/src/github/github.service.ts`

- Added `?state=all` parameter to the GitHub API URL in the `getRepoPulls` method
- Now correctly fetches all pull requests (merged, closed, and open)

### 3. Fix Email Verification Link to Point to Backend API

**Issue:** Email verification links were built with the frontend base URL (port 4200) instead of the backend API URL (port 5050), resulting in 404 errors.

**Files:**
- `webiu-server/src/email/email.service.ts`
- `webiu-server/src/email/templates/verify-email.template.ts`
- `webiu-server/.env.example`

**Changes:**
- Updated email service to use `BACKEND_BASE_URL` instead of `FRONTEND_BASE_URL`
- Changed default fallback to use the backend `PORT` (5050)
- Added `BACKEND_BASE_URL` configuration to `.env.example`

## Testing

- ✅ Tested locally on `http://localhost:5050`
- ✅ `/api/projects` endpoint returns 200 OK
- ✅ PR counts accurate with `?state=all` parameter
- ✅ Email service configured correctly

## Related Issues

Fixes #415

## Checklist

- [x] Code compiles without errors
- [x] Lint checks pass
- [x] Existing tests pass
- [x] No secrets committed
- [x] Changes clearly explained