### PR TITLE
fix(publications): enforce consistent card heights for aligned grid layout

### DIFF
--- a/webiu-ui/src/app/components/publications-card/publications-card.component.scss
+++ b/webiu-ui/src/app/components/publications-card/publications-card.component.scss
@@ -9,7 +9,10 @@
   border: 2px solid var(--publications-card-border);
   background: var(--publications-card-bg);
   box-shadow: 0px 4px 24px 0px var(--publications-card-box-shadow);
-  width: 500px;
+  width: 100%;
+  max-width: 500px;
+  height: 100%;
+  box-sizing: border-box;
 
   a {
     color: var(--primary-dark, var(--primary-dark, #0a0a15));
@@ -39,12 +42,12 @@
 
 @media screen and (max-width: 600px) {
   .publications__card {
-    width: 400px;
+    max-width: 400px;
   }
 }
 
 @media screen and (max-width: 450px) {
   .publications__card {
-    width: 300px;
+    max-width: 300px;
   }
 }

--- a/webiu-ui/src/app/page/publications/publications.component.scss
+++ b/webiu-ui/src/app/page/publications/publications.component.scss
@@ -41,7 +41,13 @@
     display: grid;
     gap: 25px;
     grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: 1fr;
     padding: 20px;
+
+    app-publications-card {
+      display: flex;
+      height: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #428 
## Summary
Publication cards on the Publications page currently render with varying heights due to differences in title and content length. This leads to staggered grid rows and visual misalignment across columns.

This PR standardizes card height to ensure a consistent and balanced grid layout regardless of content length.

## Current Behavior
- Card heights vary based on title/description length
- Grid rows appear uneven and misaligned
- Visual scan across publications is inconsistent

## Expected Behavior
- All publication cards maintain equal height within the grid
- Rows align cleanly across columns
- Layout appears visually balanced and predictable

## Impact
Improves visual consistency and readability of the Publications page, especially when scanning multiple entries in grid view.

## Solution
Applies a layout strategy to enforce equal card heights across the grid. This includes:
- Grid/flex alignment to stretch cards uniformly
- Minimum/fixed height constraints
- Line clamping for overflowing title/description text

<img width="1321" height="1056" alt="Screenshot 2026-02-26 at 7 22 04 PM" src="https://github.com/user-attachments/assets/1f545530-afed-4ce5-9a5e-a3cf6ce647a4" />

## Notes
The issue is most noticeable when titles wrap to multiple lines, increasing individual card height and breaking row alignment.