### PR TITLE
feat(project-details): add Contributors & Community Activity section

### DIFF
--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -38,6 +38,16 @@ export class ProjectController {
   async getProjectInsights(@Param('name') name: string) {
     return this.projectService.getProjectInsights(name);
   }
+
+  /**
+   * GET /api/projects/:name/contributors
+   * Returns the list of contributors for a project.
+   */
+  @Get(':name/contributors')
+  @Header('Cache-Control', 'public, max-age=300')
+  async getProjectContributors(@Param('name') name: string) {
+    return this.projectService.getProjectContributors(name);
+  }
 }
 
 @Controller('api/issues')

--- a/webiu-ui/src/app/components/project-contributors/project-contributors.component.html
+++ b/webiu-ui/src/app/components/project-contributors/project-contributors.component.html
@@ -1,0 +1,80 @@
+<div class="contributors-section">
+  <header class="section-header">
+    <h3>Contributors & Activity</h3>
+    @if (!loading && contributors.length > 0) {
+      <div class="community-badges">
+        <span class="community-badge engagement">
+          <i class="fas fa-users"></i>
+          {{ contributors.length }} Contributors
+        </span>
+        @if (topContributorShare > 0) {
+          <span class="community-badge distribution" [title]="'Top contributor: ' + topContributorShare + '% share'">
+            <i class="fas fa-chart-pie"></i>
+            {{ topContributorShare }}% Concentration
+          </span>
+        }
+      </div>
+    }
+  </header>
+
+  <div class="contributors-grid">
+    @if (loading) {
+      <div class="loading-overlay">
+        <div class="skeleton-grid">
+          @for (i of [1,2,3,4,5]; track i) {
+            <div class="skeleton-avatar"></div>
+          }
+        </div>
+      </div>
+    } @else if (error) {
+      <div class="error-state glass-card">
+        <span>{{ error }}</span>
+      </div>
+    } @else if (contributors.length > 0) {
+      <!-- Top Contributors List -->
+      <div class="contributors-list-card glass-card">
+        <div class="list-header">
+          <h4>Top Contributors</h4>
+        </div>
+        <div class="contributors-scroll">
+          @for (contributor of contributors | slice:0:15; track contributor.login) {
+            <a [href]="contributor.html_url" target="_blank" class="contributor-item" [attr.title]="contributor.login + ': ' + contributor.contributions + ' contributions'">
+              <div class="avatar-wrapper">
+                <img [src]="contributor.avatar_url" [alt]="contributor.login" loading="lazy">
+                <span class="contribution-count">{{ contributor.contributions }}</span>
+              </div>
+              <span class="username">{{ contributor.login }}</span>
+            </a>
+          }
+        </div>
+        @if (contributors.length > 15) {
+          <div class="more-contributors">
+            <span>+ {{ contributors.length - 15 }} more contributors</span>
+          </div>
+        }
+      </div>
+
+      <!-- Detail Signals -->
+      <div class="signals-grid">
+        <div class="signal-card glass-card">
+          <span class="label">Community Size</span>
+          <div class="value-row">
+            <span class="value">{{ contributors.length }}</span>
+            <span class="trend">Total</span>
+          </div>
+        </div>
+        <div class="signal-card glass-card">
+          <span class="label">Engagement</span>
+          <div class="value-row">
+            <span class="value">{{ totalContributions }}</span>
+            <span class="trend">Total Commits</span>
+          </div>
+        </div>
+      </div>
+    } @else {
+      <div class="empty-state glass-card">
+        <p>No contributors found for this project.</p>
+      </div>
+    }
+  </div>
+</div>

--- a/webiu-ui/src/app/components/project-contributors/project-contributors.component.scss
+++ b/webiu-ui/src/app/components/project-contributors/project-contributors.component.scss
@@ -1,0 +1,232 @@
+@import "../../app.component.scss";
+
+.contributors-section {
+  margin-top: 3rem;
+  padding-bottom: 2rem;
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    h3 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--text-color, #fff);
+      margin: 0;
+    }
+
+    .community-badges {
+      display: flex;
+      gap: 0.75rem;
+
+      .community-badge {
+        padding: 0.4rem 0.8rem;
+        border-radius: 20px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        color: rgba(255, 255, 255, 0.8);
+
+        i {
+          font-size: 0.8rem;
+        }
+
+        &.engagement {
+          border-color: rgba(74, 144, 226, 0.3);
+          color: #4a90e2;
+        }
+
+        &.distribution {
+          border-color: rgba(80, 227, 194, 0.3);
+          color: #50e3c2;
+        }
+      }
+    }
+  }
+}
+
+.contributors-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+
+  @media (max-width: 992px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.contributors-list-card {
+  .list-header {
+    margin-bottom: 1.5rem;
+    h4 {
+      font-size: 1.1rem;
+      margin: 0;
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
+
+  .contributors-scroll {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 1.5rem;
+    max-height: 300px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 10px;
+    }
+  }
+
+  .contributor-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+    transition: transform 0.2s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      .username {
+        color: #4a90e2;
+      }
+    }
+
+    .avatar-wrapper {
+      position: relative;
+      margin-bottom: 0.5rem;
+
+      img {
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+        border: 2px solid rgba(255, 255, 255, 0.1);
+        object-fit: cover;
+      }
+
+      .contribution-count {
+        position: absolute;
+        bottom: -5px;
+        right: -5px;
+        background: #4a90e2;
+        color: white;
+        font-size: 0.6rem;
+        padding: 2px 5px;
+        border-radius: 10px;
+        min-width: 18px;
+        text-align: center;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+      }
+    }
+
+    .username {
+      font-size: 0.75rem;
+      color: rgba(255, 255, 255, 0.6);
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      transition: color 0.2s ease;
+    }
+  }
+
+  .more-contributors {
+    margin-top: 1.5rem;
+    text-align: center;
+    span {
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.4);
+      background: rgba(255, 255, 255, 0.05);
+      padding: 0.4rem 1rem;
+      border-radius: 20px;
+    }
+  }
+}
+
+.signals-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+
+  .signal-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .label {
+      font-size: 0.8rem;
+      color: rgba(255, 255, 255, 0.5);
+      margin-bottom: 0.5rem;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .value-row {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
+
+      .value {
+        font-size: 1.75rem;
+        font-weight: 700;
+        color: #fff;
+      }
+
+      .trend {
+        font-size: 0.8rem;
+        color: #50e3c2;
+        font-weight: 500;
+      }
+    }
+  }
+}
+
+.loading-overlay {
+  padding: 2rem;
+  .skeleton-grid {
+    display: flex;
+    gap: 1rem;
+    .skeleton-avatar {
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      background: linear-gradient(90deg, rgba(255, 255, 255, 0.05) 25%, rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0.05) 75%);
+      background-size: 200% 100%;
+      animation: skeleton-loading 1.5s infinite;
+    }
+  }
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.error-state, .empty-state {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-style: italic;
+}

--- a/webiu-ui/src/app/components/project-contributors/project-contributors.component.ts
+++ b/webiu-ui/src/app/components/project-contributors/project-contributors.component.ts
@@ -1,0 +1,72 @@
+import { Component, Input, OnInit, inject, DestroyRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import { ProjectCacheService } from '../../services/project-cache.service';
+import { Contributor } from '../../page/projects/project.model';
+
+@Component({
+  selector: 'app-project-contributors',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './project-contributors.component.html',
+  styleUrls: ['./project-contributors.component.scss'],
+})
+export class ProjectContributorsComponent implements OnInit {
+  @Input() projectName = '';
+
+  private projectService = inject(ProjectCacheService);
+  private destroyRef = inject(DestroyRef);
+
+  contributors: Contributor[] = [];
+  loading = true;
+  error: string | null = null;
+
+  // Community Signals
+  totalContributions = 0;
+  topContributorShare = 0;
+  recentContributorsCount = 0;
+
+  ngOnInit(): void {
+    if (this.projectName) {
+      this.fetchContributors();
+    }
+  }
+
+  private fetchContributors(): void {
+    this.loading = true;
+    this.projectService
+      .getProjectContributors(this.projectName)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.contributors = data;
+          this.calculateSignals();
+          this.loading = false;
+        },
+        error: () => {
+          this.error = 'Unable to load contributors.';
+          this.loading = false;
+        },
+      });
+  }
+
+  private calculateSignals(): void {
+    if (!this.contributors.length) return;
+
+    this.totalContributions = this.contributors.reduce(
+      (acc, c) => acc + c.contributions,
+      0,
+    );
+    
+    if (this.totalContributions > 0) {
+      this.topContributorShare = Math.round(
+        (this.contributors[0].contributions / this.totalContributions) * 100,
+      );
+    }
+
+    // In a real scenario, we'd filters by date if available in API. 
+    // For now, we'll treat all as "active" for community size.
+    this.recentContributorsCount = this.contributors.length;
+  }
+}

--- a/webiu-ui/src/app/page/project-details/project-details.component.html
+++ b/webiu-ui/src/app/page/project-details/project-details.component.html
@@ -36,5 +36,7 @@
     <app-project-basic-info [project]="project"></app-project-basic-info>
 
     <app-project-insights [projectName]="projectName!"></app-project-insights>
+
+    <app-project-contributors [projectName]="projectName!"></app-project-contributors>
   }
 </div>

--- a/webiu-ui/src/app/page/project-details/project-details.component.ts
+++ b/webiu-ui/src/app/page/project-details/project-details.component.ts
@@ -7,6 +7,7 @@ import { ProjectCacheService } from '../../services/project-cache.service';
 import { Project } from '../projects/project.model';
 import { ProjectBasicInfoComponent } from '../../components/project-basic-info/project-basic-info.component';
 import { ProjectInsightsComponent } from '../../components/project-insights/project-insights.component';
+import { ProjectContributorsComponent } from '../../components/project-contributors/project-contributors.component';
 
 @Component({
   selector: 'app-project-details',
@@ -16,6 +17,7 @@ import { ProjectInsightsComponent } from '../../components/project-insights/proj
     RouterModule,
     ProjectBasicInfoComponent,
     ProjectInsightsComponent,
+    ProjectContributorsComponent,
   ],
   templateUrl: './project-details.component.html',
   styleUrls: ['./project-details.component.scss'],

--- a/webiu-ui/src/app/page/projects/project.model.ts
+++ b/webiu-ui/src/app/page/projects/project.model.ts
@@ -156,3 +156,10 @@ export interface ProjectInsights {
   badges: InsightBadges;
   stats: InsightStats;
 }
+
+export interface Contributor {
+  login: string;
+  contributions: number;
+  avatar_url: string;
+  html_url: string;
+}

--- a/webiu-ui/src/app/services/project-cache.service.ts
+++ b/webiu-ui/src/app/services/project-cache.service.ts
@@ -6,6 +6,7 @@ import {
   Project,
   ProjectInsights,
   ProjectResponse,
+  Contributor,
 } from '../page/projects/project.model';
 
 @Injectable({
@@ -39,6 +40,15 @@ export class ProjectCacheService {
   getProjectInsights(name: string): Observable<ProjectInsights> {
     return this.http.get<ProjectInsights>(
       `${environment.serverUrl}/api/projects/${name}/insights`,
+    );
+  }
+
+  /**
+   * Fetches the list of contributors for a project.
+   */
+  getProjectContributors(name: string): Observable<Contributor[]> {
+    return this.http.get<Contributor[]>(
+      `${environment.serverUrl}/api/projects/${name}/contributors`,
     );
   }
 }


### PR DESCRIPTION
Part of #373  
Fixes #455

## Summary

Add the **Contributors & Community Activity** section to the Project Details page, surfacing project contributors and community participation signals.

This completes the planned Project Details sections (#376, #399, #429) by introducing the community layer alongside repository metadata and insights.

## Changes

- Contributors list on `/project/:id`
- Contributor avatars and contribution counts
- Links to contributor GitHub profiles
- Total contributor count / community size
- WebiU card-based layout consistent with other sections

## Result

- Community participation visible on Project Details page  
- Contributor data accurately reflects selected project  
- Layout responsive and visually consistent with WebiU  
- No regression to existing Project Details sections  


https://github.com/user-attachments/assets/d3fee2a4-771a-4590-8759-e0fe47e9acb1


Parent: #373