### PR TITLE
fix(auth): validate Bearer scheme and reject empty tokens in JwtAuthG…

### DIFF
--- a/webiu-server/src/auth/guards/jwt-auth.guard.ts
+++ b/webiu-server/src/auth/guards/jwt-auth.guard.ts
@@ -14,11 +14,15 @@ export class JwtAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const authHeader = request.headers.authorization;
 
-    if (!authHeader) {
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
       throw new UnauthorizedException('Not authorized');
     }
 
-    const token = authHeader.replace('Bearer ', '');
+    const token = authHeader.slice(7);
+
+    if (!token) {
+      throw new UnauthorizedException('Not authorized');
+    }
 
     try {
       const decoded = this.jwtService.verify(token);


### PR DESCRIPTION
# Description closes: #462 
 
`JwtAuthGuard.canActivate()` line 21 read:

```typescript
const token = authHeader.replace('Bearer ', '');
```

`String.replace()` matches the first occurrence of the literal substring. If the header does not contain `'Bearer '` at all (e.g. `Basic dXNlcjpwYXNz`, `Bearertoken`, `bearer abc`), the full header string is left intact and forwarded to `jwtService.verify()`. The verify call then throws inside the `try` block and the guard returns `401 Token is not valid` — the wrong error. A header of `Bearer ` (scheme present, token absent) passes an empty string to verify, same outcome but for the wrong reason.

Fixed by:
1. Merging the `!authHeader` null-check and scheme check into one condition: `!authHeader || !authHeader.startsWith('Bearer ')`
2. Extracting the token with `authHeader.slice(7)` — a fixed offset, no ambiguity
3. Adding `if (!token) throw new UnauthorizedException('Not authorized')` to handle the empty-token edge case before verify is called

Fixes the incorrect scheme validation in `webiu-server/src/auth/guards/jwt-auth.guard.ts`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm run lint` passes (webiu-server)
- [x] All 83 backend unit tests pass (`npm test`)
- [x] Manual verification: send `Authorization: Basic abc123` → receives `401 Not authorized` (was `401 Token is not valid` before)
- [x] Send `Authorization: Bearer ` (no token) → receives `401 Not authorized`
- [x] Send valid `Authorization: Bearer <jwt>` → guard passes as before

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---