### PR TITLE
fix(auth): improve Bearer scheme validation and error messages in JwtAuthGuard #462

### DIFF
--- a/webiu-server/src/auth/guards/jwt-auth.guard.ts
+++ b/webiu-server/src/auth/guards/jwt-auth.guard.ts
@@ -15,10 +15,24 @@ export class JwtAuthGuard implements CanActivate {
     const authHeader = request.headers.authorization;
 
     if (!authHeader) {
-      throw new UnauthorizedException('Not authorized');
+      throw new UnauthorizedException(
+        'Authorization header is missing',
+      );
     }
 
-    const token = authHeader.replace('Bearer ', '');
+    if (!authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException(
+        'Invalid authorization scheme. Expected Bearer',
+      );
+    }
+
+    const token = authHeader.slice(7).trim();
+
+    if (!token) {
+      throw new UnauthorizedException(
+        'Bearer token is missing or empty',
+      );
+    }
 
     try {
       const decoded = this.jwtService.verify(token);


### PR DESCRIPTION
Fixes #462

## Problem
The original JwtAuthGuard had two issues:
1. Used replace('Bearer ', '') which could accept 
   non-Bearer schemes like "Basic token"
2. No validation for empty or whitespace-only tokens

## Changes Made
- Added explicit Bearer scheme check using startsWith()
- Added empty token validation using .trim()
- Added specific error messages for each case:
  - Missing header → "Authorization header is missing"
  - Wrong scheme   → "Invalid authorization scheme. Expected Bearer"  
  - Empty token    → "Bearer token is missing or empty"

## Improvements Over PR #463
- .trim() handles whitespace-only tokens
- Specific error messages help with debugging
- More readable code

## File Changed
- webiu-server/src/auth/guards/jwt-auth.guard.ts