### PR TITLE
fix: Cache key case mismatch and null result caching in getRepoContributors

### DIFF
--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -39,6 +39,22 @@ export class CacheService {
     return entry.data as T;
   }
 
+  /**
+   * Check if a key exists in the cache (not expired).
+   * Returns true even if the cached value is null.
+   */
+  has(key: string): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) return false;
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return false;
+    }
+
+    return true;
+  }
+
   set<T>(key: string, data: T, ttlSeconds?: number): void {
     const ttl = ttlSeconds ?? this.defaultTtl;
     this.cache.set(key, {

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -354,17 +354,24 @@ export class GithubService {
     orgName: string,
     repoName: string,
   ): Promise<any[] | null> {
-    const cacheKey = `contributors_${orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[] | null>(cacheKey);
-    if (cached !== null) return cached;
+    const normalizedOrgName = orgName.toLowerCase();
+    const normalizedRepoName = repoName.toLowerCase();
+    const cacheKey = `contributors_${normalizedOrgName}_${normalizedRepoName}`;
+    
+    if (this.cacheService.has(cacheKey)) {
+      const cached = this.cacheService.get<any[] | null>(cacheKey);
+      return cached;
+    }
 
     try {
       const contributors = await this.fetchAllPages(
         `${this.baseUrl}/repos/${orgName}/${repoName}/contributors`,
       );
-      this.cacheService.set(cacheKey, contributors);
+      this.cacheService.set(cacheKey, contributors, 600);
       return contributors;
     } catch {
+      // Cache null results with shorter TTL to prevent repeated failed requests
+      this.cacheService.set(cacheKey, null, 300);
       return null;
     }
   }


### PR DESCRIPTION
﻿fix: Cache key case mismatch and null result caching in getRepoContributors

This PR fixes two caching bugs in the `getRepoContributors()` method of the GitHub service:

1. Cache Key Case Mismatch: cache keys now normalize `orgName` and `repoName` to lowercase to ensure case-insensitive caching and prevent duplicate API calls.
2. Failed Requests Not Cached: failed API calls (null results) are cached with a 300s TTL to avoid repeated failed requests and reduce API traffic.

Files changed:
- webiu-server/src/github/github.service.ts
- webiu-server/src/common/cache.service.ts

Closes: #476

Checklist:
- [x] Cache keys normalized to lowercase
- [x] Null results cached with short TTL
- [x] Added `has()` method to CacheService
- [x] All changes tested and committed

Labels: bug, performance, backend, cache, github-api
