### PR TITLE
fix: prevent malformed API call in ProjectsCardComponent for no-results fallback (#475)

### DIFF
--- a/webiu-ui/src/app/components/projects-card/projects-card.component.ts
+++ b/webiu-ui/src/app/components/projects-card/projects-card.component.ts
@@ -20,8 +20,8 @@ export class ProjectsCardComponent implements OnInit {
   @Input() topics: string[] = [];
   @Input() createdAt!: string;
   @Input() updatedAt!: string;
-  @Input() org?: string;      // ← changed to optional
-  @Input() repo?: string;     // ← changed to optional
+  @Input() org?: string;
+  @Input() repo?: string;
 
   issueCount = 0;
   pullRequestCount = 0;
@@ -41,7 +41,6 @@ export class ProjectsCardComponent implements OnInit {
   fetchIssuesAndPRs(): void {
     
     if (!this.org || !this.repo) {
-      console.warn('Skipping API call: org or repo missing (fallback card)');
       this.initialized = true;
       return;
     }


### PR DESCRIPTION
## What does this PR fix?

Fixes bug #475 where "No projects found" fallback card was making invalid API request (`org=undefined&repo=undefined`).

## Changes
- Made `org` and `repo` optional inputs
- Added guard in `ngOnInit()` and `fetchIssuesAndPRs()`
- No API call for fallback card

## Screenshots

<img width="959" height="481" alt="image" src="https://github.com/user-attachments/assets/52ae2998-946a-4cdc-ba43-e4b60fe5c0c1" />
)

## Testing
- Search non-existent project → no invalid API call
- Normal project cards → issues/PRs still load correctly

