### PR TITLE
test(server): fix project service and resolver spec drift

### DIFF
--- a/webiu-server/src/graphql/project.resolver.spec.ts
+++ b/webiu-server/src/graphql/project.resolver.spec.ts
@@ -49,21 +49,39 @@ describe('ProjectResolver', () => {
         },
       ];
       mockProjectService.getAllProjects.mockResolvedValue({
+        total: 2,
+        page: 1,
+        limit: 10,
         repositories: mockRepositories,
       });
 
       const result = await resolver.repositories(1, 10);
 
-      expect(result).toEqual(mockRepositories);
+      expect(result).toEqual({
+        total: 2,
+        page: 1,
+        limit: 10,
+        repositories: mockRepositories,
+      });
       expect(mockProjectService.getAllProjects).toHaveBeenCalledWith(1, 10);
     });
 
     it('should return empty array when no repositories exist', async () => {
-      mockProjectService.getAllProjects.mockResolvedValue({ repositories: [] });
+      mockProjectService.getAllProjects.mockResolvedValue({
+        total: 0,
+        page: 1,
+        limit: 10,
+        repositories: [],
+      });
 
       const result = await resolver.repositories(1, 10);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        total: 0,
+        page: 1,
+        limit: 10,
+        repositories: [],
+      });
     });
   });
 });

--- a/webiu-server/src/project/project.service.spec.ts
+++ b/webiu-server/src/project/project.service.spec.ts
@@ -15,10 +15,10 @@ describe('ProjectService', () => {
 
   const mockGithubService = {
     org: 'c2siorg',
-    getOrgRepos: jest.fn(),
+    getAllOrgReposSorted: jest.fn(),
+    getRepoPullCount: jest.fn(),
     getRepoPulls: jest.fn(),
     getRepoIssues: jest.fn(),
-    getPublicUserProfile: jest.fn(),
     getRepo: jest.fn(),
     getRepoLanguages: jest.fn(),
   };
@@ -52,55 +52,44 @@ describe('ProjectService', () => {
 
   describe('getAllProjects', () => {
     it('should return { repositories } with pull request counts using native pagination', async () => {
-      mockGithubService.getOrgRepos.mockResolvedValue([
+      mockGithubService.getAllOrgReposSorted.mockResolvedValue([
         { name: 'repo1' },
         { name: 'repo2' },
       ]);
-      mockGithubService.getRepoPulls
-        .mockResolvedValueOnce([{ id: 1 }, { id: 2 }])
-        .mockResolvedValueOnce([{ id: 3 }]);
-      mockGithubService.getPublicUserProfile.mockResolvedValue({
-        public_repos: 20,
-      });
+      mockGithubService.getRepoPullCount
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(1);
 
       const result = await service.getAllProjects(1, 10);
 
-      expect(result.total).toBe(20);
+      expect(result.total).toBe(2);
       expect(result.repositories).toHaveLength(2);
       expect(result.repositories[0].pull_requests).toBe(2);
       expect(result.repositories[1].pull_requests).toBe(1);
-      expect(mockGithubService.getOrgRepos).toHaveBeenCalledWith(1, 10);
-      expect(mockGithubService.getPublicUserProfile).toHaveBeenCalledWith(
-        'c2siorg',
-      );
+      expect(mockGithubService.getAllOrgReposSorted).toHaveBeenCalledTimes(1);
     });
 
     it('should cache the response per page/limit', async () => {
-      mockGithubService.getOrgRepos.mockResolvedValue([{ name: 'repo1' }]);
-      mockGithubService.getRepoPulls.mockResolvedValue([]);
-      mockGithubService.getPublicUserProfile.mockResolvedValue({
-        public_repos: 5,
-      });
+      mockGithubService.getAllOrgReposSorted.mockResolvedValue([
+        { name: 'repo1' },
+      ]);
+      mockGithubService.getRepoPullCount.mockResolvedValue(0);
 
       await service.getAllProjects(1, 10);
       await service.getAllProjects(1, 10);
 
       // Only called once due to cache
-      expect(mockGithubService.getOrgRepos).toHaveBeenCalledTimes(1);
-      expect(mockGithubService.getPublicUserProfile).toHaveBeenCalledTimes(1);
+      expect(mockGithubService.getAllOrgReposSorted).toHaveBeenCalledTimes(1);
     });
 
     it('should handle PR fetch errors gracefully per repo', async () => {
-      mockGithubService.getOrgRepos.mockResolvedValue([
+      mockGithubService.getAllOrgReposSorted.mockResolvedValue([
         { name: 'repo1' },
         { name: 'repo2' },
       ]);
-      mockGithubService.getRepoPulls
+      mockGithubService.getRepoPullCount
         .mockRejectedValueOnce(new Error('fail'))
-        .mockResolvedValueOnce([{ id: 1 }]);
-      mockGithubService.getPublicUserProfile.mockResolvedValue({
-        public_repos: 10,
-      });
+        .mockResolvedValueOnce(1);
 
       const result = await service.getAllProjects(1, 10);
 
@@ -109,7 +98,9 @@ describe('ProjectService', () => {
     });
 
     it('should throw InternalServerErrorException on total failure', async () => {
-      mockGithubService.getOrgRepos.mockRejectedValue(new Error('API error'));
+      mockGithubService.getAllOrgReposSorted.mockRejectedValue(
+        new Error('API error'),
+      );
 
       await expect(service.getAllProjects(1, 10)).rejects.toThrow(
         InternalServerErrorException,


### PR DESCRIPTION
## Description

  Backend unit tests on webiu-2026-pre-gsoc had 5 failing tests due to test-
  suite drift after service/resolver contract updates:

  - project.service.spec.ts still mocked getOrgRepos/getRepoPulls patterns while
    ProjectService.getAllProjects() now uses getAllOrgReposSorted() +
    getRepoPullCount().
  - project.resolver.spec.ts expected a raw repository array, while resolver now
    returns paginated shape { total, page, limit, repositories }.

  This PR updates only the affected specs to match current implementation
  contracts. No runtime/backend service logic was changed.

  Fixes # (backend test drift issue)

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality
    to not work as expected)
  - [ ] This change requires a documentation update

  ## How Has This Been Tested?

  - Reproduced failing baseline on webiu-2026-pre-gsoc:
      - cd webiu-server
      - npm test -- --runInBand
      - Observed 5 failures in:
          - src/project/project.service.spec.ts (3)
          - src/graphql/project.resolver.spec.ts (2)
  - Verified after fixes:
      - cd webiu-server
      - npm run lint
      - npm test -- --runInBand

  Result:

  - 11/11 test suites passed
  - 83/83 tests passed
  - [x] npm run lint (webiu-server)
  - [x] npm test -- --runInBand (webiu-server)

  ## Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature
    works
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged and published in downstream
    modules
