### PR TITLE
fix: return empty array instead of null in getRepoContributors

### DIFF
--- a/webiu-server/src/github/github.service.spec.ts
+++ b/webiu-server/src/github/github.service.spec.ts
@@ -137,10 +137,10 @@ describe('GithubService', () => {
       expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
 
-    it('should return null on error', async () => {
+    it('should return empty array on error', async () => {
       mockedAxios.get.mockRejectedValue(new Error('API error'));
       const result = await service.getRepoContributors('c2siorg', 'repo1');
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
   });
 

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -353,13 +353,13 @@ export class GithubService {
   async getRepoContributors(
     orgName: string,
     repoName: string,
-  ): Promise<any[] | null> {
+  ): Promise<any[]> {
     const normalizedOrgName = orgName.toLowerCase();
     const normalizedRepoName = repoName.toLowerCase();
     const cacheKey = `contributors_${normalizedOrgName}_${normalizedRepoName}`;
-    
-    if (this.cacheService.has(cacheKey)) {
-      const cached = this.cacheService.get<any[] | null>(cacheKey);
+
+    const cached = this.cacheService.get<any[]>(cacheKey);
+    if (cached !== null) {
       return cached;
     }
 
@@ -370,9 +370,9 @@ export class GithubService {
       this.cacheService.set(cacheKey, contributors, 600);
       return contributors;
     } catch {
-      // Cache null results with shorter TTL to prevent repeated failed requests
-      this.cacheService.set(cacheKey, null, 300);
-      return null;
+      // Cache empty array with shorter TTL to prevent repeated failed requests
+      this.cacheService.set(cacheKey, [], 300);
+      return [];
     }
   }
 

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -292,10 +292,6 @@ export class ProjectService {
           .catch(() => []),
       ]);
 
-      if (!contributors) {
-        return [];
-      }
-
       const pureIssues = issues.filter((i: any) => !i.pull_request);
 
       const enriched = contributors.map((contributor: any) => {


### PR DESCRIPTION
## Description

`GithubService.getRepoContributors()` was returning `null` on API errors instead of an empty array `[]`. This caused a type contract mismatch — callers expected `any[]` but received `null`, which could lead to uncaught `TypeError: Cannot read properties of null` at runtime when the result was iterated or spread.

**Changes made:**
- Changed return type from `Promise<any[] | null>` to `Promise<any[]>`
- Replaced `return null` in the catch block with `return []`
- Cache now stores `[]` (with a shorter 300s TTL) on error to prevent repeated failed requests
- Replaced `cacheService.has()` + `cacheService.get()` double-call with a single `get() !== null` check
- Removed now-redundant null guard `if (!contributors) { return []; }` in `ProjectService.getProjectContributors()`

Fixes #507

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated the existing unit test in `github.service.spec.ts`:

- Test: `'should return empty array on error'` — mocks `axios.get` to reject, asserts `result` equals `[]` (previously `toBeNull()`)
- All 83 existing tests continue to pass with no regressions

**Test config:** Jest via `npm test` in `webiu-server/`

- [x] Test A — `getRepoContributors` returns `[]` on API error
- [x] Test B — `getRepoContributors` returns contributors array on success (existing test, untouched)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules