### PR TITLE
feat(cache): add ETag support and refresh() to CacheService

### DIFF
--- a/webiu-server/src/common/cache.service.spec.ts
+++ b/webiu-server/src/common/cache.service.spec.ts
@@ -20,19 +20,34 @@ describe('CacheService', () => {
     expect(service.get('nonexistent')).toBeNull();
   });
 
-  it('should return null for expired entries', async () => {
-    service.set('key', 'value', 1); // expires in 1 second
+  it('should return null for expired entries', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    service.set('key', 'value', 1);
     expect(service.get('key')).toBe('value');
 
-    // Wait for expiry
-    await new Promise((resolve) => setTimeout(resolve, 1100));
+    jest.advanceTimersByTime(1100);
     expect(service.get('key')).toBeNull();
+
+    jest.useRealTimers();
   });
 
   it('should delete a specific key', () => {
     service.set('key', 'value', 60);
     service.delete('key');
     expect(service.get('key')).toBeNull();
+  });
+
+  it('has() should return true even for falsy cached values', () => {
+    // get() returns null for missing keys, so callers must use has() when the
+    // cached value itself could be falsy (0, false, '', [])
+    service.set('zero', 0 as unknown, 60);
+    service.set('empty', [], 60);
+    service.set('falsy', false as unknown, 60);
+    expect(service.has('zero')).toBe(true);
+    expect(service.has('empty')).toBe(true);
+    expect(service.has('falsy')).toBe(true);
+    expect(service.has('nonexistent')).toBe(false);
   });
 
   it('should clear all entries', () => {
@@ -50,78 +65,133 @@ describe('CacheService', () => {
   });
 
   describe('TTL configuration', () => {
-    afterEach(() => {
-      jest.restoreAllMocks();
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(0);
     });
+    afterEach(() => jest.useRealTimers());
 
     it('should use CACHE_TTL_SECONDS from config as default TTL', () => {
-      const now = 1_000_000;
-      jest
-        .spyOn(Date, 'now')
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 59_000)
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 61_000);
-
       const s = new CacheService(mockConfig('60'));
+
       s.set('key', 'value');
+      jest.advanceTimersByTime(59_000);
       expect(s.get('key')).toBe('value');
 
       s.set('key2', 'value2');
+      jest.advanceTimersByTime(61_000);
       expect(s.get('key2')).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is missing', () => {
-      const now = 1_000_000;
-      jest
-        .spyOn(Date, 'now')
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 301_000);
-
       const s = new CacheService(mockConfig(undefined));
       s.set('key', 'value');
+      jest.advanceTimersByTime(301_000);
       expect(s.get('key')).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is invalid (NaN)', () => {
-      const now = 1_000_000;
-      jest
-        .spyOn(Date, 'now')
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 301_000);
-
       const s = new CacheService(mockConfig('abc'));
       s.set('key', 'value');
+      jest.advanceTimersByTime(301_000);
       expect(s.get('key')).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is zero or negative', () => {
-      const now = 1_000_000;
-      jest
-        .spyOn(Date, 'now')
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 301_000);
-
       const s = new CacheService(mockConfig('0'));
       s.set('key', 'value');
+      jest.advanceTimersByTime(301_000);
       expect(s.get('key')).toBeNull();
     });
 
     it('should use defaultTtl when set() is called without explicit ttlSeconds', () => {
-      const now = 1_000_000;
-      jest
-        .spyOn(Date, 'now')
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 119_000)
-        .mockReturnValueOnce(now)
-        .mockReturnValueOnce(now + 121_000);
-
       const s = new CacheService(mockConfig('120'));
+
       s.set('key', 'value');
+      jest.advanceTimersByTime(119_000);
       expect(s.get('key')).toBe('value');
 
       s.set('key2', 'value2');
+      jest.advanceTimersByTime(121_000);
       expect(s.get('key2')).toBeNull();
+    });
+  });
+
+  describe('getEtag()', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(0);
+    });
+    afterEach(() => jest.useRealTimers());
+
+    it('should return the etag stored alongside data', () => {
+      service.set('key', 'value', 60, '"abc123"');
+      expect(service.getEtag('key')).toBe('"abc123"');
+    });
+
+    it('should return undefined when no etag was stored', () => {
+      service.set('key', 'value', 60);
+      expect(service.getEtag('key')).toBeUndefined();
+    });
+
+    it('should return undefined for a missing key', () => {
+      expect(service.getEtag('nonexistent')).toBeUndefined();
+    });
+
+    it('should return undefined and evict an expired entry', () => {
+      service.set('key', 'value', 1, '"etag"');
+      jest.advanceTimersByTime(1100);
+      expect(service.getEtag('key')).toBeUndefined();
+      // entry should have been evicted — get() also returns null
+      expect(service.get('key')).toBeNull();
+    });
+
+    it('should not affect data retrieval when etag is present', () => {
+      service.set('key', { count: 42 }, 60, '"xyz"');
+      expect(service.get<{ count: number }>('key')).toEqual({ count: 42 });
+      expect(service.getEtag('key')).toBe('"xyz"');
+    });
+  });
+
+  describe('refresh()', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(0);
+    });
+    afterEach(() => jest.useRealTimers());
+
+    it('should return true and extend the TTL of a live entry', () => {
+      service.set('key', 'value', 60);
+
+      // t=30s: still alive (original TTL=60s), extend by 120s → new expiry at t=150s
+      jest.advanceTimersByTime(30_000);
+      expect(service.refresh('key', 120)).toBe(true);
+
+      // t=130s: past original expiry (60s) but within new expiry (150s)
+      jest.advanceTimersByTime(100_000);
+      expect(service.get('key')).toBe('value');
+
+      // t=151s: past new expiry (150s) → evicted
+      jest.advanceTimersByTime(21_000);
+      expect(service.get('key')).toBeNull();
+    });
+
+    it('should return false for a missing key', () => {
+      expect(service.refresh('nonexistent', 60)).toBe(false);
+    });
+
+    it('should return false and evict an already-expired entry', () => {
+      service.set('key', 'value', 1);
+      jest.advanceTimersByTime(1100);
+      expect(service.refresh('key', 60)).toBe(false);
+      expect(service.get('key')).toBeNull();
+    });
+
+    it('should preserve data and etag after refresh', () => {
+      service.set('key', { stars: 10 }, 60, '"etag-v1"');
+      service.refresh('key', 120);
+      expect(service.get<{ stars: number }>('key')).toEqual({ stars: 10 });
+      expect(service.getEtag('key')).toBe('"etag-v1"');
     });
   });
 });

--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -4,12 +4,14 @@ import { ConfigService } from '@nestjs/config';
 interface CacheEntry<T> {
   data: T;
   expiresAt: number;
+  /** ETag header value returned by GitHub for this response, if any. */
+  etag?: string;
 }
 
 @Injectable()
 export class CacheService {
   private readonly logger = new Logger(CacheService.name);
-  private cache = new Map<string, CacheEntry<any>>();
+  private cache = new Map<string, CacheEntry<unknown>>();
   private readonly defaultTtl: number;
 
   constructor(private configService: ConfigService) {
@@ -27,7 +29,7 @@ export class CacheService {
     }
   }
 
-  get<T>(key: string): T | null {
+  get<T = unknown>(key: string): T | null {
     const entry = this.cache.get(key);
     if (!entry) return null;
 
@@ -55,12 +57,48 @@ export class CacheService {
     return true;
   }
 
-  set<T>(key: string, data: T, ttlSeconds?: number): void {
+  /**
+   * Returns the stored ETag for a cache key, or undefined if the key
+   * does not exist or has expired.
+   */
+  getEtag(key: string): string | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    return entry.etag;
+  }
+
+  set<T = unknown>(key: string, data: T, ttlSeconds?: number, etag?: string): void {
     const ttl = ttlSeconds ?? this.defaultTtl;
     this.cache.set(key, {
       data,
       expiresAt: Date.now() + ttl * 1000,
+      ...(etag !== undefined ? { etag } : {}),
     });
+  }
+
+  /**
+   * Extends the TTL of an existing, non-expired cache entry without
+   * changing its data or ETag. Returns true if the entry existed and
+   * was refreshed, false if it was missing or already expired.
+   */
+  refresh(key: string, ttlSeconds?: number): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) return false;
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return false;
+    }
+
+    const ttl = ttlSeconds ?? this.defaultTtl;
+    entry.expiresAt = Date.now() + ttl * 1000;
+    return true;
   }
 
   delete(key: string): void {


### PR DESCRIPTION
## Description

Adds ETag support to `CacheService` by allowing cache entries to store an optional `etag` alongside cached data. Introduces a `refresh()` method to extend an entry's TTL without modifying its data or ETag.

### Motivation and Context

Currently, the backend cache stores only response data with a fixed TTL. However, GitHub API responses include `ETag` headers, which allow the server to check if data has changed using conditional requests (`If-None-Match`). By adding ETag support to the cache layer, the backend can later reuse cached data when GitHub reports that the resource has not changed.

This helps to:
- reduce unnecessary GitHub API calls
- lower the chance of hitting GitHub rate limits
- improve backend efficiency

This change does not modify existing API behavior. It prepares the cache layer so future updates in `GithubService` can use ETag-based conditional requests. Unit tests were also expanded to verify ETag storage, TTL refresh behavior, and correct handling of falsy cached values with `has()`.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran `npm test` in `webiu-server/` — 93 tests, all passing.

New unit tests cover:
- [x] ETag storage and retrieval via `getEtag()`
- [x] TTL extension via `refresh()`, including expiry boundary checks
- [x] Correct handling of falsy cached values in `has()`
- [x] All timer-dependent tests use `jest.useFakeTimers()` + `jest.setSystemTime(0)` for deterministic behaviour across Jest timer modes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
