### PR TITLE
feat(cache): prevent duplicate API calls with request deduplication

### DIFF
--- a/webiu-server/src/common/cache.service.spec.ts
+++ b/webiu-server/src/common/cache.service.spec.ts
@@ -153,6 +153,111 @@ describe('CacheService', () => {
     });
   });
 
+  describe('dedup()', () => {
+    it('returns cached value immediately without calling fetcher', async () => {
+      service.set('key', 'cached-value', 60);
+      const fetcher = jest.fn();
+
+      const result = await service.dedup('key', fetcher);
+
+      expect(result).toBe('cached-value');
+      expect(fetcher).not.toHaveBeenCalled();
+    });
+
+    it('calls fetcher once and stores result when cache is cold', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ data: 'fresh', ttlSeconds: 60 });
+
+      const result = await service.dedup('key', fetcher);
+
+      expect(result).toBe('fresh');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(service.get('key')).toBe('fresh');
+    });
+
+    it('deduplicates concurrent callers — fetcher called exactly once', async () => {
+      let resolveIt: (v: { data: string; ttlSeconds: number }) => void;
+      const fetcher = jest.fn(
+        () =>
+          new Promise<{ data: string; ttlSeconds: number }>((res) => {
+            resolveIt = res;
+          }),
+      );
+
+      // Fire 5 concurrent callers before the fetch resolves
+      const promises = [
+        service.dedup('key', fetcher),
+        service.dedup('key', fetcher),
+        service.dedup('key', fetcher),
+        service.dedup('key', fetcher),
+        service.dedup('key', fetcher),
+      ];
+
+      // Resolve the single in-flight fetch
+      resolveIt({ data: 'result', ttlSeconds: 60 });
+      const results = await Promise.all(promises);
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(results).toEqual(['result', 'result', 'result', 'result', 'result']);
+      expect(service.get('key')).toBe('result');
+    });
+
+    it('second call after resolution returns cached value without refetching', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ data: 'value', ttlSeconds: 60 });
+      await service.dedup('key', fetcher);
+
+      // Cache is now warm; a second call should return the cached value without invoking fetcher2
+      const fetcher2 = jest.fn().mockResolvedValue({ data: 'value2', ttlSeconds: 60 });
+      const result = await service.dedup('key', fetcher2);
+
+      // Should return cache hit, not call second fetcher
+      expect(result).toBe('value');
+      expect(fetcher2).not.toHaveBeenCalled();
+    });
+
+    it('removes in-flight entry and propagates error when fetcher rejects', async () => {
+      const fetcher = jest.fn().mockRejectedValue(new Error('GitHub API down'));
+
+      await expect(service.dedup('key', fetcher)).rejects.toThrow('GitHub API down');
+
+      // After failure, a subsequent call should try the fetcher again (not stuck in-flight)
+      const fetcher2 = jest.fn().mockResolvedValue({ data: 'recovered', ttlSeconds: 60 });
+      const result = await service.dedup('key', fetcher2);
+      expect(result).toBe('recovered');
+      expect(fetcher2).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not deduplicate different keys — each key fetches independently', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ data: 'value', ttlSeconds: 60 });
+
+      await Promise.all([
+        service.dedup('key1', fetcher),
+        service.dedup('key2', fetcher),
+      ]);
+
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('clear() also removes all in-flight entries', async () => {
+      let resolveIt: (v: { data: string }) => void;
+      const fetcher = jest.fn(
+        () => new Promise<{ data: string }>((res) => { resolveIt = res; }),
+      );
+
+      const p = service.dedup('key', fetcher);
+      service.clear();
+
+      // After clear, a new call should create a fresh in-flight entry
+      const fetcher2 = jest.fn().mockResolvedValue({ data: 'fresh' });
+      const result2 = await service.dedup('key', fetcher2);
+      expect(result2).toBe('fresh');
+      expect(fetcher2).toHaveBeenCalledTimes(1);
+
+      // Resolve the original promise to avoid unhandled rejection
+      resolveIt({ data: 'late' });
+      await p;
+    });
+  });
+
   describe('refresh()', () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -14,6 +14,13 @@ export class CacheService {
   private cache = new Map<string, CacheEntry<unknown>>();
   private readonly defaultTtl: number;
 
+  /**
+   * Tracks in-flight fetch promises keyed by cache key.
+   * Prevents cache stampedes: concurrent callers for the same cold-cache key
+   * share one promise instead of each firing an independent HTTP request.
+   */
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+
   constructor(private configService: ConfigService) {
     const raw = this.configService.get<string>('CACHE_TTL_SECONDS');
     const parsed = parseInt(raw, 10);
@@ -101,11 +108,49 @@ export class CacheService {
     return true;
   }
 
+  /**
+   * Deduplicates concurrent fetches for the same cache key.
+   *
+   * If a cached value already exists it is returned immediately.
+   * If a fetch for this key is already in-flight, the same promise is returned
+   * to all concurrent callers — only one HTTP request is ever made.
+   * Once the fetch resolves the result is stored via `set()` using the provided
+   * TTL, the in-flight entry is removed, and all waiters receive the result.
+   *
+   * @param key       Cache key
+   * @param fetcher   Async function that performs the actual fetch and returns
+   *                  `{ data: T; ttlSeconds?: number; etag?: string }`. The caller
+   *                  controls TTL and the optional ETag for conditional-request support.
+   */
+  async dedup<T = unknown>(
+    key: string,
+    fetcher: () => Promise<{ data: T; ttlSeconds?: number; etag?: string }>,
+  ): Promise<T> {
+    const cached = this.get<T>(key);
+    if (cached !== null) return cached;
+
+    const existing = this.inFlight.get(key);
+    if (existing) return existing as Promise<T>;
+
+    const promise = fetcher()
+      .then(({ data, ttlSeconds, etag }) => {
+        this.set(key, data, ttlSeconds, etag);
+        return data;
+      })
+      .finally(() => {
+        this.inFlight.delete(key);
+      });
+
+    this.inFlight.set(key, promise as Promise<unknown>);
+    return promise;
+  }
+
   delete(key: string): void {
     this.cache.delete(key);
   }
 
   clear(): void {
     this.cache.clear();
+    this.inFlight.clear();
   }
 }


### PR DESCRIPTION
## Description

Adds in-flight request deduplication to `CacheService` to prevent cache stampedes.

When the cache is cold, multiple concurrent requests for the same key would each fire an independent HTTP request to GitHub. This fix stores a `Map<string, Promise>` of in-flight fetches so all concurrent callers share one promise and only one request goes out.

`getAllOrgReposSorted()` in `GithubService` is ported to use `dedup()` as the end-to-end proof.

Fixes #531

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

7 unit tests added to `cache.service.spec.ts`:

- [x] Cache hit returns immediately without calling fetcher
- [x] Cold cache calls fetcher once and stores result
- [x] 5 concurrent callers for the same key share one fetch (fetcher called exactly once)
- [x] Second call after resolution returns cached value without refetching
- [x] Rejected fetch clears in-flight entry so next call retries normally
- [x] Different keys are not deduplicated together
- [x] `clear()` flushes both cache and in-flight entries

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (106/106)
- [ ] Any dependent changes have been merged and published in downstream modules