### PR TITLE
fix(cache): honor cached empty/falsy values

### DIFF
--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -20,7 +20,7 @@ export class ContributorService {
   async getAllContributors() {
     const cacheKey = 'all_contributors';
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const orgName = this.githubService.org;

--- a/webiu-server/src/github/github.graphql.service.ts
+++ b/webiu-server/src/github/github.graphql.service.ts
@@ -45,7 +45,7 @@ export class GithubGraphqlService {
     const cacheKey = `graphql_prs_${normalizedUsername}`;
 
     const cached = this.cacheService.get(cacheKey);
-    if (cached) {
+    if (cached !== null) {
       return cached;
     }
 

--- a/webiu-server/src/github/github.service.spec.ts
+++ b/webiu-server/src/github/github.service.spec.ts
@@ -142,6 +142,17 @@ describe('GithubService', () => {
       const result = await service.getRepoContributors('c2siorg', 'repo1');
       expect(result).toEqual([]);
     });
+
+    it('should cache empty array on error and avoid repeated API calls', async () => {
+      mockedAxios.get.mockRejectedValue(new Error('API error'));
+
+      const first = await service.getRepoContributors('c2siorg', 'repo1');
+      const second = await service.getRepoContributors('c2siorg', 'repo1');
+
+      expect(first).toEqual([]);
+      expect(second).toEqual([]);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('getRepo', () => {
@@ -225,6 +236,17 @@ describe('GithubService', () => {
       const result = await service.searchUserIssues('testuser');
       expect(result).toEqual([]);
     });
+
+    it('should cache empty issue results and avoid repeated API calls', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { items: [] } });
+
+      const first = await service.searchUserIssues('testuser');
+      const second = await service.searchUserIssues('testuser');
+
+      expect(first).toEqual([]);
+      expect(second).toEqual([]);
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('searchUserPullRequests', () => {
@@ -238,6 +260,17 @@ describe('GithubService', () => {
 
       // Cached
       await service.searchUserPullRequests('testuser');
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cache empty pull request results and avoid repeated API calls', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ data: { items: [] } });
+
+      const first = await service.searchUserPullRequests('testuser');
+      const second = await service.searchUserPullRequests('testuser');
+
+      expect(first).toEqual([]);
+      expect(second).toEqual([]);
       expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
   });

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -100,7 +100,7 @@ export class GithubService {
   async getAllOrgReposSorted(): Promise<GithubRepo[]> {
     const cacheKey = `all_org_repos_sorted_${this.orgName}`;
     const cached = this.cacheService.get<GithubRepo[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const repos = await this.fetchAllPages(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
@@ -153,7 +153,7 @@ export class GithubService {
     if (page !== undefined && perPage !== undefined) {
       const cacheKey = `org_repos_${this.orgName}_p${page}_pp${perPage}`;
       const cached = this.cacheService.get<any[]>(cacheKey);
-      if (cached) return cached;
+      if (cached !== null) return cached;
 
       const response = await axios.get(
         `${this.baseUrl}/orgs/${this.orgName}/repos?per_page=${perPage}&page=${page}`,
@@ -166,7 +166,7 @@ export class GithubService {
 
     const cacheKey = `org_repos_${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const repos = await this.fetchAllPages(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
@@ -182,7 +182,7 @@ export class GithubService {
   async getRepo(repoName: string): Promise<GithubRepo | null> {
     const cacheKey = `repo_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<GithubRepo>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -207,7 +207,7 @@ export class GithubService {
   async getCommitActivity(repoName: string): Promise<any[]> {
     const cacheKey = `commit_activity_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -245,7 +245,7 @@ export class GithubService {
   async getParticipationStats(repoName: string): Promise<any[]> {
     const cacheKey = `participation_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -277,7 +277,7 @@ export class GithubService {
   async getLatestRelease(repoName: string): Promise<any | null> {
     const cacheKey = `latest_release_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -302,7 +302,7 @@ export class GithubService {
   async getRepoPulls(repoName: string): Promise<any[]> {
     const cacheKey = `pulls_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const pulls = await this.fetchAllPages(
       `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls?state=all`,
@@ -314,7 +314,7 @@ export class GithubService {
   async getRepoIssues(org: string, repo: string): Promise<any[]> {
     const cacheKey = `issues_${org}_${repo}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const issues = await this.fetchAllPages(
       `${this.baseUrl}/repos/${org}/${repo}/issues`,
@@ -330,7 +330,7 @@ export class GithubService {
   async getRepoLanguages(repoName: string): Promise<Record<string, number>> {
     const cacheKey = `languages_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<Record<string, number>>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -380,7 +380,7 @@ export class GithubService {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_issues:${normalizedUsername}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const issues = await this.fetchAllSearchPages(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:issue`,
@@ -393,7 +393,7 @@ export class GithubService {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_prs:${normalizedUsername}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const prs = await this.fetchAllSearchPages(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:pr`,
@@ -440,7 +440,7 @@ export class GithubService {
   async getPublicUserProfile(username: string): Promise<any> {
     const cacheKey = `user_profile_${username}`;
     const cached = this.cacheService.get<any>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const response = await axios.get(`${this.baseUrl}/users/${username}`, {
       headers: this.headers,
@@ -483,7 +483,7 @@ export class GithubService {
       followers: number;
       following: number;
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       // ✅ Correct source of truth: GitHub profile fields (not list endpoints capped at 30)
@@ -514,7 +514,7 @@ export class GithubService {
     const normalizedQuery = query.toLowerCase();
     const cacheKey = `search_repos:${normalizedQuery}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const encoded = encodeURIComponent(query);
     const repos = await this.fetchAllSearchPages(

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -39,7 +39,7 @@ export class ProjectService {
       limit: number;
       repositories: any[];
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const allRepos = await this.githubService.getAllOrgReposSorted();
@@ -69,7 +69,7 @@ export class ProjectService {
 
     const cacheKey = `issues_pr_count_${org}_${repo}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const data = await this.githubService.getRepoIssues(org, repo);
@@ -101,7 +101,7 @@ export class ProjectService {
 
     const cacheKey = `project_details_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       // Direct fetch of a single repo as requested by maintainers
@@ -152,7 +152,7 @@ export class ProjectService {
 
     const cacheKey = `project_insights_v2_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const [project, activity, release, languages] = await Promise.all([
@@ -281,7 +281,7 @@ export class ProjectService {
 
     const cacheKey = `project_contributors_enriched_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const [contributors, pulls, issues] = await Promise.all([
@@ -345,7 +345,7 @@ export class ProjectService {
       limit: number;
       repositories: any[];
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const allRepos = await this.githubService.getAllOrgReposSorted();


### PR DESCRIPTION
## Summary
This PR fixes cache-hit checks that treated valid falsy cached values as misses.

## Changes
- Replaced truthy checks (if (cached)) with explicit null checks (if (cached !== null)) at cache call sites.
- Added regression tests to verify empty-array responses are cached and do not trigger repeated axios calls.

## Files Updated
- webiu-server/src/github/github.service.ts
- webiu-server/src/project/project.service.ts
- webiu-server/src/contributor/contributor.service.ts
- webiu-server/src/github/github.graphql.service.ts
- webiu-server/src/github/github.service.spec.ts

## Validation
- 
pm test -- src/github/github.service.spec.ts --runInBand
- 
pm test -- src/project/project.service.spec.ts --runInBand
- 
pm test -- src/contributor/contributor.service.spec.ts --runInBand
- 
px tsc --noEmit --pretty false

Closes #538