### PR TITLE
feat(server): add optional Redis distributed caching with in-memory fallback

### DIFF
--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -32,3 +32,8 @@ GMAIL_PASSWORD=your_gmail_app_password
 
 # Cache
 CACHE_TTL_SECONDS=300
+
+# Redis (optional — leave unset to use in-memory cache)
+# When set, the app uses Redis for distributed caching across multiple instances.
+# Example: redis://localhost:6379  or  rediss://user:pass@host:6380 (TLS)
+# REDIS_URL=redis://localhost:6379

--- a/webiu-server/src/common/cache.service.spec.ts
+++ b/webiu-server/src/common/cache.service.spec.ts
@@ -11,57 +11,55 @@ describe('CacheService', () => {
     service = new CacheService(mockConfig());
   });
 
-  it('should store and retrieve values', () => {
-    service.set('key', 'value', 60);
-    expect(service.get('key')).toBe('value');
+  it('should store and retrieve values', async () => {
+    await service.set('key', 'value', 60);
+    expect(await service.get('key')).toBe('value');
   });
 
-  it('should return null for missing keys', () => {
-    expect(service.get('nonexistent')).toBeNull();
+  it('should return null for missing keys', async () => {
+    expect(await service.get('nonexistent')).toBeNull();
   });
 
-  it('should return null for expired entries', () => {
+  it('should return null for expired entries', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(0);
-    service.set('key', 'value', 1);
-    expect(service.get('key')).toBe('value');
+    await service.set('key', 'value', 1);
+    expect(await service.get('key')).toBe('value');
 
     jest.advanceTimersByTime(1100);
-    expect(service.get('key')).toBeNull();
+    expect(await service.get('key')).toBeNull();
 
     jest.useRealTimers();
   });
 
-  it('should delete a specific key', () => {
-    service.set('key', 'value', 60);
-    service.delete('key');
-    expect(service.get('key')).toBeNull();
+  it('should delete a specific key', async () => {
+    await service.set('key', 'value', 60);
+    await service.delete('key');
+    expect(await service.get('key')).toBeNull();
   });
 
-  it('has() should return true even for falsy cached values', () => {
-    // get() returns null for missing keys, so callers must use has() when the
-    // cached value itself could be falsy (0, false, '', [])
-    service.set('zero', 0 as unknown, 60);
-    service.set('empty', [], 60);
-    service.set('falsy', false as unknown, 60);
-    expect(service.has('zero')).toBe(true);
-    expect(service.has('empty')).toBe(true);
-    expect(service.has('falsy')).toBe(true);
-    expect(service.has('nonexistent')).toBe(false);
+  it('has() should return true even for falsy cached values', async () => {
+    await service.set('zero', 0 as unknown, 60);
+    await service.set('empty', [], 60);
+    await service.set('falsy', false as unknown, 60);
+    expect(await service.has('zero')).toBe(true);
+    expect(await service.has('empty')).toBe(true);
+    expect(await service.has('falsy')).toBe(true);
+    expect(await service.has('nonexistent')).toBe(false);
   });
 
-  it('should clear all entries', () => {
-    service.set('key1', 'value1', 60);
-    service.set('key2', 'value2', 60);
-    service.clear();
-    expect(service.get('key1')).toBeNull();
-    expect(service.get('key2')).toBeNull();
+  it('should clear all entries', async () => {
+    await service.set('key1', 'value1', 60);
+    await service.set('key2', 'value2', 60);
+    await service.clear();
+    expect(await service.get('key1')).toBeNull();
+    expect(await service.get('key2')).toBeNull();
   });
 
-  it('should handle complex objects', () => {
+  it('should handle complex objects', async () => {
     const data = { repos: [{ name: 'repo1' }], count: 5 };
-    service.set('complex', data, 60);
-    expect(service.get('complex')).toEqual(data);
+    await service.set('complex', data, 60);
+    expect(await service.get('complex')).toEqual(data);
   });
 
   describe('TTL configuration', () => {
@@ -71,49 +69,49 @@ describe('CacheService', () => {
     });
     afterEach(() => jest.useRealTimers());
 
-    it('should use CACHE_TTL_SECONDS from config as default TTL', () => {
+    it('should use CACHE_TTL_SECONDS from config as default TTL', async () => {
       const s = new CacheService(mockConfig('60'));
 
-      s.set('key', 'value');
+      await s.set('key', 'value');
       jest.advanceTimersByTime(59_000);
-      expect(s.get('key')).toBe('value');
+      expect(await s.get('key')).toBe('value');
 
-      s.set('key2', 'value2');
+      await s.set('key2', 'value2');
       jest.advanceTimersByTime(61_000);
-      expect(s.get('key2')).toBeNull();
+      expect(await s.get('key2')).toBeNull();
     });
 
-    it('should fall back to 300s when CACHE_TTL_SECONDS is missing', () => {
+    it('should fall back to 300s when CACHE_TTL_SECONDS is missing', async () => {
       const s = new CacheService(mockConfig(undefined));
-      s.set('key', 'value');
+      await s.set('key', 'value');
       jest.advanceTimersByTime(301_000);
-      expect(s.get('key')).toBeNull();
+      expect(await s.get('key')).toBeNull();
     });
 
-    it('should fall back to 300s when CACHE_TTL_SECONDS is invalid (NaN)', () => {
+    it('should fall back to 300s when CACHE_TTL_SECONDS is invalid (NaN)', async () => {
       const s = new CacheService(mockConfig('abc'));
-      s.set('key', 'value');
+      await s.set('key', 'value');
       jest.advanceTimersByTime(301_000);
-      expect(s.get('key')).toBeNull();
+      expect(await s.get('key')).toBeNull();
     });
 
-    it('should fall back to 300s when CACHE_TTL_SECONDS is zero or negative', () => {
+    it('should fall back to 300s when CACHE_TTL_SECONDS is zero or negative', async () => {
       const s = new CacheService(mockConfig('0'));
-      s.set('key', 'value');
+      await s.set('key', 'value');
       jest.advanceTimersByTime(301_000);
-      expect(s.get('key')).toBeNull();
+      expect(await s.get('key')).toBeNull();
     });
 
-    it('should use defaultTtl when set() is called without explicit ttlSeconds', () => {
+    it('should use defaultTtl when set() is called without explicit ttlSeconds', async () => {
       const s = new CacheService(mockConfig('120'));
 
-      s.set('key', 'value');
+      await s.set('key', 'value');
       jest.advanceTimersByTime(119_000);
-      expect(s.get('key')).toBe('value');
+      expect(await s.get('key')).toBe('value');
 
-      s.set('key2', 'value2');
+      await s.set('key2', 'value2');
       jest.advanceTimersByTime(121_000);
-      expect(s.get('key2')).toBeNull();
+      expect(await s.get('key2')).toBeNull();
     });
   });
 
@@ -124,32 +122,33 @@ describe('CacheService', () => {
     });
     afterEach(() => jest.useRealTimers());
 
-    it('should return the etag stored alongside data', () => {
-      service.set('key', 'value', 60, '"abc123"');
-      expect(service.getEtag('key')).toBe('"abc123"');
+    it('should return the etag stored alongside data', async () => {
+      await service.set('key', 'value', 60, '"abc123"');
+      expect(await service.getEtag('key')).toBe('"abc123"');
     });
 
-    it('should return undefined when no etag was stored', () => {
-      service.set('key', 'value', 60);
-      expect(service.getEtag('key')).toBeUndefined();
+    it('should return undefined when no etag was stored', async () => {
+      await service.set('key', 'value', 60);
+      expect(await service.getEtag('key')).toBeUndefined();
     });
 
-    it('should return undefined for a missing key', () => {
-      expect(service.getEtag('nonexistent')).toBeUndefined();
+    it('should return undefined for a missing key', async () => {
+      expect(await service.getEtag('nonexistent')).toBeUndefined();
     });
 
-    it('should return undefined and evict an expired entry', () => {
-      service.set('key', 'value', 1, '"etag"');
+    it('should return undefined and evict an expired entry', async () => {
+      await service.set('key', 'value', 1, '"etag"');
       jest.advanceTimersByTime(1100);
-      expect(service.getEtag('key')).toBeUndefined();
-      // entry should have been evicted — get() also returns null
-      expect(service.get('key')).toBeNull();
+      expect(await service.getEtag('key')).toBeUndefined();
+      expect(await service.get('key')).toBeNull();
     });
 
-    it('should not affect data retrieval when etag is present', () => {
-      service.set('key', { count: 42 }, 60, '"xyz"');
-      expect(service.get<{ count: number }>('key')).toEqual({ count: 42 });
-      expect(service.getEtag('key')).toBe('"xyz"');
+    it('should not affect data retrieval when etag is present', async () => {
+      await service.set('key', { count: 42 }, 60, '"xyz"');
+      expect(await service.get<{ count: number }>('key')).toEqual({
+        count: 42,
+      });
+      expect(await service.getEtag('key')).toBe('"xyz"');
     });
   });
 
@@ -160,38 +159,37 @@ describe('CacheService', () => {
     });
     afterEach(() => jest.useRealTimers());
 
-    it('should return true and extend the TTL of a live entry', () => {
-      service.set('key', 'value', 60);
+    it('should return true and extend the TTL of a live entry', async () => {
+      await service.set('key', 'value', 60);
 
-      // t=30s: still alive (original TTL=60s), extend by 120s → new expiry at t=150s
       jest.advanceTimersByTime(30_000);
-      expect(service.refresh('key', 120)).toBe(true);
+      expect(await service.refresh('key', 120)).toBe(true);
 
-      // t=130s: past original expiry (60s) but within new expiry (150s)
       jest.advanceTimersByTime(100_000);
-      expect(service.get('key')).toBe('value');
+      expect(await service.get('key')).toBe('value');
 
-      // t=151s: past new expiry (150s) → evicted
       jest.advanceTimersByTime(21_000);
-      expect(service.get('key')).toBeNull();
+      expect(await service.get('key')).toBeNull();
     });
 
-    it('should return false for a missing key', () => {
-      expect(service.refresh('nonexistent', 60)).toBe(false);
+    it('should return false for a missing key', async () => {
+      expect(await service.refresh('nonexistent', 60)).toBe(false);
     });
 
-    it('should return false and evict an already-expired entry', () => {
-      service.set('key', 'value', 1);
+    it('should return false and evict an already-expired entry', async () => {
+      await service.set('key', 'value', 1);
       jest.advanceTimersByTime(1100);
-      expect(service.refresh('key', 60)).toBe(false);
-      expect(service.get('key')).toBeNull();
+      expect(await service.refresh('key', 60)).toBe(false);
+      expect(await service.get('key')).toBeNull();
     });
 
-    it('should preserve data and etag after refresh', () => {
-      service.set('key', { stars: 10 }, 60, '"etag-v1"');
-      service.refresh('key', 120);
-      expect(service.get<{ stars: number }>('key')).toEqual({ stars: 10 });
-      expect(service.getEtag('key')).toBe('"etag-v1"');
+    it('should preserve data and etag after refresh', async () => {
+      await service.set('key', { stars: 10 }, 60, '"etag-v1"');
+      await service.refresh('key', 120);
+      expect(await service.get<{ stars: number }>('key')).toEqual({
+        stars: 10,
+      });
+      expect(await service.getEtag('key')).toBe('"etag-v1"');
     });
   });
 });

--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
 
 interface CacheEntry<T> {
   data: T;
@@ -8,11 +9,17 @@ interface CacheEntry<T> {
   etag?: string;
 }
 
+interface RedisPayload<T> {
+  data: T;
+  etag?: string;
+}
+
 @Injectable()
-export class CacheService {
+export class CacheService implements OnModuleDestroy {
   private readonly logger = new Logger(CacheService.name);
-  private cache = new Map<string, CacheEntry<unknown>>();
-  private readonly defaultTtl: number;
+  private readonly memCache = new Map<string, CacheEntry<unknown>>();
+  private readonly redis: Redis | null = null;
+  readonly defaultTtl: number;
 
   constructor(private configService: ConfigService) {
     const raw = this.configService.get<string>('CACHE_TTL_SECONDS');
@@ -27,85 +34,148 @@ export class CacheService {
     } else {
       this.defaultTtl = 300;
     }
+
+    const redisUrl = this.configService.get<string>('REDIS_URL');
+    if (redisUrl) {
+      this.redis = new Redis(redisUrl, { lazyConnect: true });
+      this.redis.on('error', (err: Error) =>
+        this.logger.error('Redis connection error:', err.message),
+      );
+      this.redis
+        .connect()
+        .then(() =>
+          this.logger.log('Redis connected — using distributed cache'),
+        )
+        .catch((err: Error) =>
+          this.logger.error(
+            'Redis connect failed, falling back to in-memory cache:',
+            err.message,
+          ),
+        );
+    } else {
+      this.logger.log('No REDIS_URL configured — using in-memory cache');
+    }
   }
 
-  get<T = unknown>(key: string): T | null {
-    const entry = this.cache.get(key);
+  async onModuleDestroy(): Promise<void> {
+    if (this.redis) {
+      await this.redis.quit();
+    }
+  }
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    if (this.redis && this.redis.status === 'ready') {
+      const raw = await this.redis.get(key);
+      if (raw === null) return null;
+      const payload = JSON.parse(raw) as RedisPayload<T>;
+      return payload.data;
+    }
+
+    const entry = this.memCache.get(key);
     if (!entry) return null;
 
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
+      this.memCache.delete(key);
       return null;
     }
 
     return entry.data as T;
   }
 
-  /**
-   * Check if a key exists in the cache (not expired).
-   * Returns true even if the cached value is null.
-   */
-  has(key: string): boolean {
-    const entry = this.cache.get(key);
+  async has(key: string): Promise<boolean> {
+    if (this.redis && this.redis.status === 'ready') {
+      return (await this.redis.exists(key)) === 1;
+    }
+
+    const entry = this.memCache.get(key);
     if (!entry) return false;
 
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
+      this.memCache.delete(key);
       return false;
     }
 
     return true;
   }
 
-  /**
-   * Returns the stored ETag for a cache key, or undefined if the key
-   * does not exist or has expired.
-   */
-  getEtag(key: string): string | undefined {
-    const entry = this.cache.get(key);
+  async getEtag(key: string): Promise<string | undefined> {
+    if (this.redis && this.redis.status === 'ready') {
+      const raw = await this.redis.get(key);
+      if (raw === null) return undefined;
+      const payload = JSON.parse(raw) as RedisPayload<unknown>;
+      return payload.etag;
+    }
+
+    const entry = this.memCache.get(key);
     if (!entry) return undefined;
 
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
+      this.memCache.delete(key);
       return undefined;
     }
 
     return entry.etag;
   }
 
-  set<T = unknown>(key: string, data: T, ttlSeconds?: number, etag?: string): void {
+  async set<T = unknown>(
+    key: string,
+    data: T,
+    ttlSeconds?: number,
+    etag?: string,
+  ): Promise<void> {
     const ttl = ttlSeconds ?? this.defaultTtl;
-    this.cache.set(key, {
+
+    if (this.redis && this.redis.status === 'ready') {
+      const payload: RedisPayload<T> = {
+        data,
+        ...(etag !== undefined ? { etag } : {}),
+      };
+      await this.redis.setex(key, ttl, JSON.stringify(payload));
+      return;
+    }
+
+    this.memCache.set(key, {
       data,
       expiresAt: Date.now() + ttl * 1000,
       ...(etag !== undefined ? { etag } : {}),
     });
   }
 
-  /**
-   * Extends the TTL of an existing, non-expired cache entry without
-   * changing its data or ETag. Returns true if the entry existed and
-   * was refreshed, false if it was missing or already expired.
-   */
-  refresh(key: string, ttlSeconds?: number): boolean {
-    const entry = this.cache.get(key);
+  async refresh(key: string, ttlSeconds?: number): Promise<boolean> {
+    const ttl = ttlSeconds ?? this.defaultTtl;
+
+    if (this.redis && this.redis.status === 'ready') {
+      const result = await this.redis.expire(key, ttl);
+      return result === 1;
+    }
+
+    const entry = this.memCache.get(key);
     if (!entry) return false;
 
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
+      this.memCache.delete(key);
       return false;
     }
 
-    const ttl = ttlSeconds ?? this.defaultTtl;
     entry.expiresAt = Date.now() + ttl * 1000;
     return true;
   }
 
-  delete(key: string): void {
-    this.cache.delete(key);
+  async delete(key: string): Promise<void> {
+    if (this.redis && this.redis.status === 'ready') {
+      await this.redis.del(key);
+      return;
+    }
+
+    this.memCache.delete(key);
   }
 
-  clear(): void {
-    this.cache.clear();
+  async clear(): Promise<void> {
+    if (this.redis && this.redis.status === 'ready') {
+      await this.redis.flushdb();
+      return;
+    }
+
+    this.memCache.clear();
   }
 }

--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -19,7 +19,7 @@ export class ContributorService {
 
   async getAllContributors() {
     const cacheKey = 'all_contributors';
-    const cached = this.cacheService.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -75,7 +75,7 @@ export class ContributorService {
         }),
       );
 
-      this.cacheService.set(cacheKey, allContributors, CACHE_TTL);
+      await this.cacheService.set(cacheKey, allContributors, CACHE_TTL);
       return allContributors;
     } catch (error) {
       this.logger.error('Error in getAllContributors:', error);

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -99,7 +99,7 @@ export class GithubService {
    */
   async getAllOrgReposSorted(): Promise<GithubRepo[]> {
     const cacheKey = `all_org_repos_sorted_${this.orgName}`;
-    const cached = this.cacheService.get<GithubRepo[]>(cacheKey);
+    const cached = await this.cacheService.get<GithubRepo[]>(cacheKey);
     if (cached) return cached;
 
     const repos = await this.fetchAllPages(
@@ -110,7 +110,7 @@ export class GithubService {
       a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
     );
 
-    this.cacheService.set(cacheKey, repos, 600);
+    await this.cacheService.set(cacheKey, repos, 600);
     return repos;
   }
 
@@ -120,7 +120,7 @@ export class GithubService {
    */
   async getRepoPullCount(repoName: string): Promise<number> {
     const cacheKey = `pull_count_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<number>(cacheKey);
+    const cached = await this.cacheService.get<number>(cacheKey);
     if (cached !== null) return cached;
 
     try {
@@ -140,7 +140,7 @@ export class GithubService {
         count = response.data.length;
       }
 
-      this.cacheService.set(cacheKey, count, 600);
+      await this.cacheService.set(cacheKey, count, 600);
       return count;
     } catch {
       return 0;
@@ -152,7 +152,7 @@ export class GithubService {
   async getOrgRepos(page?: number, perPage?: number): Promise<any[]> {
     if (page !== undefined && perPage !== undefined) {
       const cacheKey = `org_repos_${this.orgName}_p${page}_pp${perPage}`;
-      const cached = this.cacheService.get<any[]>(cacheKey);
+      const cached = await this.cacheService.get<any[]>(cacheKey);
       if (cached) return cached;
 
       const response = await axios.get(
@@ -160,18 +160,18 @@ export class GithubService {
         { headers: this.headers },
       );
       const repos = response.data;
-      this.cacheService.set(cacheKey, repos, CACHE_TTL);
+      await this.cacheService.set(cacheKey, repos, CACHE_TTL);
       return repos;
     }
 
     const cacheKey = `org_repos_${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const repos = await this.fetchAllPages(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
     );
-    this.cacheService.set(cacheKey, repos);
+    await this.cacheService.set(cacheKey, repos);
     return repos;
   }
 
@@ -181,7 +181,7 @@ export class GithubService {
    */
   async getRepo(repoName: string): Promise<GithubRepo | null> {
     const cacheKey = `repo_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<GithubRepo>(cacheKey);
+    const cached = await this.cacheService.get<GithubRepo>(cacheKey);
     if (cached) return cached;
 
     try {
@@ -190,7 +190,7 @@ export class GithubService {
         { headers: this.headers },
       );
       const repo = response.data;
-      this.cacheService.set(cacheKey, repo, CACHE_TTL);
+      await this.cacheService.set(cacheKey, repo, CACHE_TTL);
       return repo;
     } catch (error: unknown) {
       if (error instanceof AxiosError && error.response?.status === 404) {
@@ -206,7 +206,7 @@ export class GithubService {
    */
   async getCommitActivity(repoName: string): Promise<any[]> {
     const cacheKey = `commit_activity_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     try {
@@ -229,7 +229,7 @@ export class GithubService {
 
       const activity = response.data;
       const STATS_CACHE_TTL = 3600 * 24; // 24 hours
-      this.cacheService.set(cacheKey, activity, STATS_CACHE_TTL);
+      await this.cacheService.set(cacheKey, activity, STATS_CACHE_TTL);
       return activity;
     } catch {
       this.logger.warn(
@@ -244,7 +244,7 @@ export class GithubService {
    */
   async getParticipationStats(repoName: string): Promise<any[]> {
     const cacheKey = `participation_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     try {
@@ -258,7 +258,7 @@ export class GithubService {
         const activity = response.data.all.map((count: number) => ({
           total: count,
         }));
-        this.cacheService.set(cacheKey, activity, 3600 * 24);
+        await this.cacheService.set(cacheKey, activity, 3600 * 24);
         return activity;
       }
       return [];
@@ -276,7 +276,7 @@ export class GithubService {
    */
   async getLatestRelease(repoName: string): Promise<any | null> {
     const cacheKey = `latest_release_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<any>(cacheKey);
+    const cached = await this.cacheService.get<any>(cacheKey);
     if (cached) return cached;
 
     try {
@@ -285,7 +285,7 @@ export class GithubService {
         { headers: this.headers },
       );
       const release = response.data;
-      this.cacheService.set(cacheKey, release, CACHE_TTL);
+      await this.cacheService.set(cacheKey, release, CACHE_TTL);
       return release;
     } catch (error: unknown) {
       if (error instanceof AxiosError && error.response?.status === 404) {
@@ -301,25 +301,25 @@ export class GithubService {
 
   async getRepoPulls(repoName: string): Promise<any[]> {
     const cacheKey = `pulls_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const pulls = await this.fetchAllPages(
       `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls?state=all`,
     );
-    this.cacheService.set(cacheKey, pulls);
+    await this.cacheService.set(cacheKey, pulls);
     return pulls;
   }
 
   async getRepoIssues(org: string, repo: string): Promise<any[]> {
     const cacheKey = `issues_${org}_${repo}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const issues = await this.fetchAllPages(
       `${this.baseUrl}/repos/${org}/${repo}/issues`,
     );
-    this.cacheService.set(cacheKey, issues);
+    await this.cacheService.set(cacheKey, issues);
     return issues;
   }
 
@@ -329,7 +329,8 @@ export class GithubService {
    */
   async getRepoLanguages(repoName: string): Promise<Record<string, number>> {
     const cacheKey = `languages_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<Record<string, number>>(cacheKey);
+    const cached =
+      await this.cacheService.get<Record<string, number>>(cacheKey);
     if (cached) return cached;
 
     try {
@@ -338,7 +339,7 @@ export class GithubService {
         { headers: this.headers },
       );
       const languages = response.data;
-      this.cacheService.set(cacheKey, languages, CACHE_TTL);
+      await this.cacheService.set(cacheKey, languages, CACHE_TTL);
       return languages;
     } catch (error: unknown) {
       const axiosErr = error instanceof AxiosError ? error : null;
@@ -350,15 +351,12 @@ export class GithubService {
     }
   }
 
-  async getRepoContributors(
-    orgName: string,
-    repoName: string,
-  ): Promise<any[]> {
+  async getRepoContributors(orgName: string, repoName: string): Promise<any[]> {
     const normalizedOrgName = orgName.toLowerCase();
     const normalizedRepoName = repoName.toLowerCase();
     const cacheKey = `contributors_${normalizedOrgName}_${normalizedRepoName}`;
 
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached !== null) {
       return cached;
     }
@@ -367,11 +365,11 @@ export class GithubService {
       const contributors = await this.fetchAllPages(
         `${this.baseUrl}/repos/${orgName}/${repoName}/contributors`,
       );
-      this.cacheService.set(cacheKey, contributors, 600);
+      await this.cacheService.set(cacheKey, contributors, 600);
       return contributors;
     } catch {
       // Cache empty array with shorter TTL to prevent repeated failed requests
-      this.cacheService.set(cacheKey, [], 300);
+      await this.cacheService.set(cacheKey, [], 300);
       return [];
     }
   }
@@ -379,20 +377,20 @@ export class GithubService {
   async searchUserIssues(username: string): Promise<any[]> {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_issues:${normalizedUsername}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const issues = await this.fetchAllSearchPages(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:issue`,
     );
-    this.cacheService.set(cacheKey, issues);
+    await this.cacheService.set(cacheKey, issues);
     return issues;
   }
 
   async searchUserPullRequests(username: string): Promise<any[]> {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_prs:${normalizedUsername}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const prs = await this.fetchAllSearchPages(
@@ -426,7 +424,7 @@ export class GithubService {
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     );
 
-    this.cacheService.set(cacheKey, enrichedPrs);
+    await this.cacheService.set(cacheKey, enrichedPrs);
     return enrichedPrs;
   }
 
@@ -439,13 +437,13 @@ export class GithubService {
 
   async getPublicUserProfile(username: string): Promise<any> {
     const cacheKey = `user_profile_${username}`;
-    const cached = this.cacheService.get<any>(cacheKey);
+    const cached = await this.cacheService.get<any>(cacheKey);
     if (cached) return cached;
 
     const response = await axios.get(`${this.baseUrl}/users/${username}`, {
       headers: this.headers,
     });
-    this.cacheService.set(cacheKey, response.data);
+    await this.cacheService.set(cacheKey, response.data);
     return response.data;
   }
 
@@ -479,7 +477,7 @@ export class GithubService {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `user_social:${normalizedUsername}`;
 
-    const cached = this.cacheService.get<{
+    const cached = await this.cacheService.get<{
       followers: number;
       following: number;
     }>(cacheKey);
@@ -499,7 +497,7 @@ export class GithubService {
         following: userResponse.data?.following ?? 0,
       };
 
-      this.cacheService.set(cacheKey, result);
+      await this.cacheService.set(cacheKey, result);
       return result;
     } catch (error) {
       this.logger.error(
@@ -513,7 +511,7 @@ export class GithubService {
   async searchOrgRepos(query: string): Promise<any[]> {
     const normalizedQuery = query.toLowerCase();
     const cacheKey = `search_repos:${normalizedQuery}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cached = await this.cacheService.get<any[]>(cacheKey);
     if (cached) return cached;
 
     const encoded = encodeURIComponent(query);
@@ -521,7 +519,7 @@ export class GithubService {
       `${this.baseUrl}/search/repositories?q=${encoded}+org:${this.orgName}`,
     );
 
-    this.cacheService.set(cacheKey, repos);
+    await this.cacheService.set(cacheKey, repos);
     return repos;
   }
 }

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -33,7 +33,7 @@ export class ProjectService {
 
   async getAllProjects(page = 1, limit = 10) {
     const cacheKey = `projects_p${page}_pp${limit}`;
-    const cached = this.cacheService.get<{
+    const cached = await this.cacheService.get<{
       total: number;
       page: number;
       limit: number;
@@ -51,7 +51,7 @@ export class ProjectService {
       const enriched = await this.enrichWithPullCounts(pageRepos);
 
       const result = { total, page, limit, repositories: enriched };
-      this.cacheService.set(cacheKey, result, CACHE_TTL);
+      await this.cacheService.set(cacheKey, result, CACHE_TTL);
       return result;
     } catch (error) {
       this.logger.error(
@@ -68,7 +68,7 @@ export class ProjectService {
     }
 
     const cacheKey = `issues_pr_count_${org}_${repo}`;
-    const cached = this.cacheService.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -78,7 +78,7 @@ export class ProjectService {
       const pullRequests = data.filter((item) => item.pull_request).length;
 
       const result = { issues, pullRequests };
-      this.cacheService.set(cacheKey, result);
+      await this.cacheService.set(cacheKey, result);
       return result;
     } catch (error) {
       this.logger.error(
@@ -100,7 +100,7 @@ export class ProjectService {
     }
 
     const cacheKey = `project_details_${name}`;
-    const cached = this.cacheService.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -123,7 +123,7 @@ export class ProjectService {
         pull_requests: pulls.length,
       };
 
-      this.cacheService.set(cacheKey, result, CACHE_TTL);
+      await this.cacheService.set(cacheKey, result, CACHE_TTL);
       return result;
     } catch (error: unknown) {
       if (error instanceof NotFoundException) throw error;
@@ -151,7 +151,7 @@ export class ProjectService {
     }
 
     const cacheKey = `project_insights_v2_${name}`;
-    const cached = this.cacheService.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -257,7 +257,7 @@ export class ProjectService {
         },
       };
 
-      this.cacheService.set(cacheKey, result, INSIGHTS_CACHE_TTL);
+      await this.cacheService.set(cacheKey, result, INSIGHTS_CACHE_TTL);
       return result;
     } catch (error: unknown) {
       if (error instanceof NotFoundException) throw error;
@@ -280,7 +280,7 @@ export class ProjectService {
     }
 
     const cacheKey = `project_contributors_enriched_${name}`;
-    const cached = this.cacheService.get(cacheKey);
+    const cached = await this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -317,7 +317,7 @@ export class ProjectService {
         };
       });
 
-      this.cacheService.set(cacheKey, enriched, CACHE_TTL);
+      await this.cacheService.set(cacheKey, enriched, CACHE_TTL);
       return enriched;
     } catch (error) {
       this.logger.error(
@@ -339,7 +339,7 @@ export class ProjectService {
 
     const normalizedQuery = query.toLowerCase();
     const cacheKey = `projects_search_${normalizedQuery}_p${page}_pp${limit}`;
-    const cached = this.cacheService.get<{
+    const cached = await this.cacheService.get<{
       total: number;
       page: number;
       limit: number;
@@ -363,7 +363,7 @@ export class ProjectService {
       const enriched = await this.enrichWithPullCounts(pageRepos);
 
       const result = { total, page, limit, repositories: enriched };
-      this.cacheService.set(cacheKey, result, CACHE_TTL);
+      await this.cacheService.set(cacheKey, result, CACHE_TTL);
       return result;
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
Closes #534

## Description

Implements optional Redis-backed distributed caching in `CacheService`. When `REDIS_URL` is configured, all cache operations (get/set/has/delete/refresh/getEtag) are delegated to Redis via `ioredis`, enabling shared cache state across multiple server instances with persistence across restarts.

When `REDIS_URL` is absent, existing in-memory behaviour is fully preserved — no breaking changes.

**Key design decisions:**
- `CacheService` methods are now `async` to support both backends transparently
- Redis uses `SETEX` for TTL-aware writes and stores ETags inside the JSON payload
- Connection failure on startup logs a warning and gracefully falls back to in-memory cache
- `OnModuleDestroy` cleanly closes the Redis connection

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```bash
cd webiu-server && npm test 

```
All 99 existing tests pass with no Redis instance running (falls back to in-memory)
cache.service.spec.ts updated to await all async cache calls
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules