### PR TITLE
feat: add schema-aware sanitization layer for GitHub API responses (#547)

### DIFF
--- a/docs/webiu.postman_collection.json
+++ b/docs/webiu.postman_collection.json
@@ -11,6 +11,24 @@
             "value": "http://localhost:5050",
             "type": "string",
             "description": "Backend base URL. Change this to point to a different environment."
+        },
+        {
+            "key": "githubOrg",
+            "value": "c2siorg",
+            "type": "string",
+            "description": "GitHub organisation name. Change this to test against a different organisation."
+        },
+        {
+            "key": "githubRepo",
+            "value": "Webiu",
+            "type": "string",
+            "description": "GitHub repository name. Change this to test against a different repository."
+        },
+        {
+            "key": "githubUsername",
+            "value": "octocat",
+            "type": "string",
+            "description": "GitHub username. Change this to test against a different user."
         }
     ],
     "item": [
@@ -25,14 +43,8 @@
                         "header": [],
                         "url": {
                             "raw": "{{baseUrl}}/api/projects/projects",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "projects",
-                                "projects"
-                            ]
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "projects", "projects"]
                         },
                         "description": "Returns all repositories in the c2siorg GitHub organisation, enriched with open pull-request counts.\n\nCached for 5 minutes on the backend."
                     },
@@ -41,12 +53,7 @@
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{\n  \"repositories\": [\n    {\n      \"id\": 123456789,\n      \"name\": \"Webiu\",\n      \"full_name\": \"c2siorg/Webiu\",\n      \"description\": \"The official website for C2SI and SCoRe Lab\",\n      \"html_url\": \"https://github.com/c2siorg/Webiu\",\n      \"stargazers_count\": 42,\n      \"forks_count\": 18,\n      \"open_issues_count\": 5,\n      \"language\": \"TypeScript\",\n      \"topics\": [\"angular\", \"nestjs\", \"open-source\"],\n      \"visibility\": \"public\",\n      \"default_branch\": \"master\",\n      \"pull_requests\": 3\n    }\n  ]\n}"
                         }
                     ]
@@ -57,24 +64,18 @@
                         "method": "GET",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/api/issues/issuesAndPr?org=c2siorg&repo=Webiu",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "issues",
-                                "issuesAndPr"
-                            ],
+                            "raw": "{{baseUrl}}/api/issues/issuesAndPr?org={{githubOrg}}&repo={{githubRepo}}",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "issues", "issuesAndPr"],
                             "query": [
                                 {
                                     "key": "org",
-                                    "value": "c2siorg",
+                                    "value": "{{githubOrg}}",
                                     "description": "GitHub organisation name (required)"
                                 },
                                 {
                                     "key": "repo",
-                                    "value": "Webiu",
+                                    "value": "{{githubRepo}}",
                                     "description": "Repository name (required)"
                                 }
                             ]
@@ -86,24 +87,14 @@
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{\n  \"issues\": 5,\n  \"pullRequests\": 3\n}"
                         },
                         {
                             "name": "400 Bad Request — Missing params",
                             "status": "Bad Request",
                             "code": 400,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{\n  \"statusCode\": 400,\n  \"message\": \"Organization and repository are required\",\n  \"error\": \"Bad Request\"\n}"
                         }
                     ]
@@ -121,29 +112,18 @@
                         "header": [],
                         "url": {
                             "raw": "{{baseUrl}}/api/contributor/contributors",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "contributor",
-                                "contributors"
-                            ]
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "contributor", "contributors"]
                         },
-                        "description": "Returns an aggregated leaderboard of all contributors across every repository in the c2siorg organisation.\n\nCached for 5 minutes. This is a heavy endpoint — it fetches all repos and their contributors."
+                        "description": "Returns an aggregated leaderboard of all contributors across every repository in the c2siorg organisation.\n\nCached for 5 minutes."
                     },
                     "response": [
                         {
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "[\n  {\n    \"login\": \"octocat\",\n    \"contributions\": 247,\n    \"repos\": [\"Webiu\", \"SCoRe-Lab-Website\"],\n    \"avatar_url\": \"https://avatars.githubusercontent.com/u/583231?v=4\"\n  }\n]"
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
+                            "body": "[\n  {\n    \"login\": \"{{githubUsername}}\",\n    \"contributions\": 247,\n    \"repos\": [\"Webiu\", \"SCoRe-Lab-Website\"],\n    \"avatar_url\": \"https://avatars.githubusercontent.com/u/583231?v=4\"\n  }\n]"
                         }
                     ]
                 },
@@ -153,30 +133,18 @@
                         "method": "GET",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/api/contributor/issues/octocat",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "contributor",
-                                "issues",
-                                "octocat"
-                            ]
+                            "raw": "{{baseUrl}}/api/contributor/issues/{{githubUsername}}",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "contributor", "issues", "{{githubUsername}}"]
                         },
-                        "description": "Returns all issues created by a specific GitHub user within the c2siorg organisation.\n\nReplace `octocat` in the URL with the target GitHub username."
+                        "description": "Returns all issues created by a specific GitHub user within the c2siorg organisation.\n\nChange the `githubUsername` collection variable to target a different user."
                     },
                     "response": [
                         {
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{\n  \"issues\": [\n    {\n      \"id\": 987654321,\n      \"number\": 42,\n      \"title\": \"Fix navbar overflow on mobile\",\n      \"html_url\": \"https://github.com/c2siorg/Webiu/issues/42\",\n      \"state\": \"open\",\n      \"created_at\": \"2024-01-15T10:30:00Z\",\n      \"updated_at\": \"2024-01-16T08:00:00Z\",\n      \"repository_url\": \"https://api.github.com/repos/c2siorg/Webiu\"\n    }\n  ]\n}"
                         }
                     ]
@@ -187,30 +155,18 @@
                         "method": "GET",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/api/contributor/pull-requests/octocat",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "contributor",
-                                "pull-requests",
-                                "octocat"
-                            ]
+                            "raw": "{{baseUrl}}/api/contributor/pull-requests/{{githubUsername}}",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "contributor", "pull-requests", "{{githubUsername}}"]
                         },
-                        "description": "Returns all pull requests created by a specific GitHub user within the c2siorg organisation. Includes merge status for closed PRs.\n\nReplace `octocat` in the URL with the target GitHub username."
+                        "description": "Returns all pull requests created by a specific GitHub user within the c2siorg organisation.\n\nChange the `githubUsername` collection variable to target a different user."
                     },
                     "response": [
                         {
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{\n  \"pullRequests\": [\n    {\n      \"id\": 111222333,\n      \"number\": 17,\n      \"title\": \"feat: add dark mode toggle\",\n      \"html_url\": \"https://github.com/c2siorg/Webiu/pull/17\",\n      \"state\": \"closed\",\n      \"merged_at\": \"2024-02-01T14:00:00Z\",\n      \"created_at\": \"2024-01-28T09:00:00Z\",\n      \"updated_at\": \"2024-02-01T14:00:00Z\",\n      \"repository_url\": \"https://api.github.com/repos/c2siorg/Webiu\"\n    }\n  ]\n}"
                         }
                     ]
@@ -221,334 +177,21 @@
                         "method": "GET",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/api/contributor/stats/octocat",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "contributor",
-                                "stats",
-                                "octocat"
-                            ]
+                            "raw": "{{baseUrl}}/api/contributor/stats/{{githubUsername}}",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "contributor", "stats", "{{githubUsername}}"]
                         },
-                        "description": "Returns both issues and pull requests for a user in a single request. Equivalent to calling /issues/:username and /pull-requests/:username in parallel.\n\nReplace `octocat` in the URL with the target GitHub username."
+                        "description": "Returns both issues and pull requests for a user in a single request.\n\nChange the `githubUsername` collection variable to target a different user."
                     },
                     "response": [
                         {
                             "name": "200 OK — Success",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"issues\": [\n    {\n      \"id\": 987654321,\n      \"number\": 42,\n      \"title\": \"Fix navbar overflow on mobile\",\n      \"html_url\": \"https://github.com/c2siorg/Webiu/issues/42\",\n      \"state\": \"open\",\n      \"created_at\": \"2024-01-15T10:30:00Z\"\n    }\n  ],\n  \"pullRequests\": [\n    {\n      \"id\": 111222333,\n      \"number\": 17,\n      \"title\": \"feat: add dark mode toggle\",\n      \"html_url\": \"https://github.com/c2siorg/Webiu/pull/17\",\n      \"state\": \"closed\",\n      \"merged_at\": \"2024-02-01T14:00:00Z\",\n      \"created_at\": \"2024-01-28T09:00:00Z\"\n    }\n  ]\n}"
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
+                            "body": "{\n  \"issues\": [],\n  \"pullRequests\": []\n}"
                         }
                     ]
-                }
-            ]
-        },
-        {
-            "name": "Authentication",
-            "description": "Email/password authentication endpoints.\n\n⚠️ These currently return 501 Not Implemented because they require a MongoDB database connection. They are scaffolded and ready to enable once a database is connected.",
-            "item": [
-                {
-                    "name": "Register",
-                    "request": {
-                        "method": "POST",
-                        "header": [
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            }
-                        ],
-                        "body": {
-                            "mode": "raw",
-                            "raw": "{\n  \"name\": \"John Doe\",\n  \"email\": \"johndoe@example.com\",\n  \"password\": \"password123\",\n  \"confirmPassword\": \"password123\",\n  \"githubId\": \"johndoe\"\n}",
-                            "options": {
-                                "raw": {
-                                    "language": "json"
-                                }
-                            }
-                        },
-                        "url": {
-                            "raw": "{{baseUrl}}/api/v1/auth/register",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "v1",
-                                "auth",
-                                "register"
-                            ]
-                        },
-                        "description": "Registers a new user account.\n\nFields:\n- `name` (required): Full name\n- `email` (required): Valid email address\n- `password` (required): Minimum 6 characters\n- `confirmPassword` (required): Must match `password`\n- `githubId` (optional): GitHub username"
-                    },
-                    "response": [
-                        {
-                            "name": "201 Created — Success",
-                            "status": "Created",
-                            "code": 201,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"status\": \"success\",\n  \"message\": \"User registered successfully\",\n  \"data\": {\n    \"user\": {\n      \"id\": \"userId123\",\n      \"name\": \"John Doe\",\n      \"email\": \"johndoe@example.com\"\n    },\n    \"token\": \"<JWT_TOKEN>\"\n  }\n}"
-                        },
-                        {
-                            "name": "400 Bad Request — Passwords don't match",
-                            "status": "Bad Request",
-                            "code": 400,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"Passwords do not match\"\n}"
-                        },
-                        {
-                            "name": "501 Not Implemented — DB not connected",
-                            "status": "Not Implemented",
-                            "code": 501,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"statusCode\": 501,\n  \"message\": \"Registration requires MongoDB. Connect a database to enable this feature.\"\n}"
-                        }
-                    ]
-                },
-                {
-                    "name": "Login",
-                    "request": {
-                        "method": "POST",
-                        "header": [
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            }
-                        ],
-                        "body": {
-                            "mode": "raw",
-                            "raw": "{\n  \"email\": \"johndoe@example.com\",\n  \"password\": \"password123\"\n}",
-                            "options": {
-                                "raw": {
-                                    "language": "json"
-                                }
-                            }
-                        },
-                        "url": {
-                            "raw": "{{baseUrl}}/api/v1/auth/login",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "v1",
-                                "auth",
-                                "login"
-                            ]
-                        },
-                        "description": "Logs in an existing user and returns a JWT token.\n\nFields:\n- `email` (required): Valid email address\n- `password` (required): Account password"
-                    },
-                    "response": [
-                        {
-                            "name": "200 OK — Success",
-                            "status": "OK",
-                            "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"status\": \"success\",\n  \"message\": \"Login successful\",\n  \"data\": {\n    \"user\": {\n      \"id\": \"userId123\",\n      \"name\": \"John Doe\",\n      \"email\": \"johndoe@example.com\",\n      \"githubId\": \"johndoe\"\n    },\n    \"token\": \"<JWT_TOKEN>\"\n  }\n}"
-                        },
-                        {
-                            "name": "401 Unauthorized — Wrong credentials",
-                            "status": "Unauthorized",
-                            "code": 401,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"status\": \"error\",\n  \"message\": \"Invalid email or password\"\n}"
-                        },
-                        {
-                            "name": "501 Not Implemented — DB not connected",
-                            "status": "Not Implemented",
-                            "code": 501,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"statusCode\": 501,\n  \"message\": \"Login requires MongoDB. Connect a database to enable this feature.\"\n}"
-                        }
-                    ]
-                },
-                {
-                    "name": "Verify Email",
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{baseUrl}}/api/v1/auth/verify-email?token=<VERIFICATION_TOKEN>",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "v1",
-                                "auth",
-                                "verify-email"
-                            ],
-                            "query": [
-                                {
-                                    "key": "token",
-                                    "value": "<VERIFICATION_TOKEN>",
-                                    "description": "Email verification token received via email after registration"
-                                }
-                            ]
-                        },
-                        "description": "Verifies a user's email address using the token sent in the verification email after registration."
-                    },
-                    "response": [
-                        {
-                            "name": "200 OK — Success",
-                            "status": "OK",
-                            "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"status\": \"success\",\n  \"message\": \"Email verified successfully\"\n}"
-                        },
-                        {
-                            "name": "501 Not Implemented — DB not connected",
-                            "status": "Not Implemented",
-                            "code": 501,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
-                            "body": "{\n  \"statusCode\": 501,\n  \"message\": \"Email verification requires MongoDB. Connect a database to enable this feature.\"\n}"
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "OAuth",
-            "description": "OAuth endpoints redirect the browser to the provider's authorization page. They are not JSON APIs — open them in a browser, not via Postman's Send button.\n\nAfter authorization, the backend redirects to the frontend with user data in the URL query string.",
-            "item": [
-                {
-                    "name": "Google OAuth — Initiate",
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{baseUrl}}/auth/google",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "auth",
-                                "google"
-                            ]
-                        },
-                        "description": "Initiates Google OAuth 2.0 flow. Open this URL in a browser — it redirects to Google's consent screen.\n\nRequired env vars: GOOGLE_CLIENT_ID, GOOGLE_REDIRECT_URI"
-                    },
-                    "response": []
-                },
-                {
-                    "name": "Google OAuth — Callback",
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{baseUrl}}/auth/google/callback?code=<AUTH_CODE>",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "auth",
-                                "google",
-                                "callback"
-                            ],
-                            "query": [
-                                {
-                                    "key": "code",
-                                    "value": "<AUTH_CODE>",
-                                    "description": "Authorization code provided by Google (handled automatically)"
-                                }
-                            ]
-                        },
-                        "description": "Google OAuth callback — called automatically by Google after user grants permission. Do not call this directly.\n\nOn success, redirects to: http://localhost:4200?user=<URL_ENCODED_USER_JSON>"
-                    },
-                    "response": []
-                },
-                {
-                    "name": "GitHub OAuth — Initiate",
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{baseUrl}}/auth/github",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "auth",
-                                "github"
-                            ]
-                        },
-                        "description": "Initiates GitHub OAuth flow. Open this URL in a browser — it redirects to GitHub's authorization page.\n\nRequired env vars: GITHUB_CLIENT_ID, GITHUB_REDIRECT_URI"
-                    },
-                    "response": []
-                },
-                {
-                    "name": "GitHub OAuth — Callback",
-                    "request": {
-                        "method": "GET",
-                        "header": [],
-                        "url": {
-                            "raw": "{{baseUrl}}/auth/github/callback?code=<AUTH_CODE>",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "auth",
-                                "github",
-                                "callback"
-                            ],
-                            "query": [
-                                {
-                                    "key": "code",
-                                    "value": "<AUTH_CODE>",
-                                    "description": "Authorization code provided by GitHub (handled automatically)"
-                                }
-                            ]
-                        },
-                        "description": "GitHub OAuth callback — called automatically by GitHub after user grants permission. Do not call this directly.\n\nOn success, redirects to: http://localhost:4200?user=<URL_ENCODED_USER_JSON>"
-                    },
-                    "response": []
                 }
             ]
         },
@@ -562,30 +205,18 @@
                         "method": "GET",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/api/user/followersAndFollowing/octocat",
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "path": [
-                                "api",
-                                "user",
-                                "followersAndFollowing",
-                                "octocat"
-                            ]
+                            "raw": "{{baseUrl}}/api/user/followersAndFollowing/{{githubUsername}}",
+                            "host": ["{{baseUrl}}"],
+                            "path": ["api", "user", "followersAndFollowing", "{{githubUsername}}"]
                         },
-                        "description": "⚠️ Placeholder endpoint — returns a stub response. Full implementation is pending.\n\nReplace `octocat` in the URL with the target GitHub username."
+                        "description": "Placeholder endpoint. Replace `githubUsername` collection variable with target GitHub username."
                     },
                     "response": [
                         {
                             "name": "200 OK — Stub response",
                             "status": "OK",
                             "code": 200,
-                            "header": [
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/json"
-                                }
-                            ],
+                            "header": [{"key": "Content-Type", "value": "application/json"}],
                             "body": "{ \"0\": 0 }"
                         }
                     ]

--- a/webiu-server/src/common/sanitizers/githubResponseSanitizer.ts
+++ b/webiu-server/src/common/sanitizers/githubResponseSanitizer.ts
@@ -1,0 +1,69 @@
+/**
+ * githubResponseSanitizer.ts
+ * Schema-aware sanitization layer for GitHub API responses
+ * Fixes Issue #547 — Arush Kumar
+ */
+
+export function sanitizeRepository(repo: any) {
+    if (!repo || typeof repo !== 'object') return null;
+    return {
+        id: repo.id ?? null,
+        name: repo.name ?? null,
+        full_name: repo.full_name ?? null,
+        description: repo.description ?? null,
+        html_url: repo.html_url ?? null,
+        stargazers_count: repo.stargazers_count ?? 0,
+        forks_count: repo.forks_count ?? 0,
+        open_issues_count: repo.open_issues_count ?? 0,
+        language: repo.language ?? null,
+        topics: Array.isArray(repo.topics) ? repo.topics : [],
+        updated_at: repo.updated_at ?? null,
+        archived: repo.archived ?? false,
+    };
+}
+
+export function sanitizeContributor(contributor: any) {
+    if (!contributor || typeof contributor !== 'object') return null;
+    return {
+        login: contributor.login ?? null,
+        id: contributor.id ?? null,
+        avatar_url: contributor.avatar_url ?? null,
+        html_url: contributor.html_url ?? null,
+        contributions: contributor.contributions ?? 0,
+        type: contributor.type ?? null,
+    };
+}
+
+export function sanitizeIssue(issue: any) {
+    if (!issue || typeof issue !== 'object') return null;
+    return {
+        id: issue.id ?? null,
+        number: issue.number ?? null,
+        title: issue.title ?? null,
+        html_url: issue.html_url ?? null,
+        state: issue.state ?? null,
+        created_at: issue.created_at ?? null,
+        updated_at: issue.updated_at ?? null,
+        pull_request: issue.pull_request ? true : undefined,
+        labels: Array.isArray(issue.labels)
+            ? issue.labels.map((l: any) => ({
+                name: l.name ?? null,
+                color: l.color ?? null,
+            }))
+            : [],
+    };
+}
+
+export function sanitizePullRequest(pr: any) {
+    if (!pr || typeof pr !== 'object') return null;
+    return {
+        id: pr.id ?? null,
+        number: pr.number ?? null,
+        title: pr.title ?? null,
+        html_url: pr.html_url ?? null,
+        state: pr.state ?? null,
+        created_at: pr.created_at ?? null,
+        updated_at: pr.updated_at ?? null,
+        merged_at: pr.merged_at ?? null,
+    };
+}

--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -5,8 +5,9 @@ import {
 } from '@nestjs/common';
 import { GithubService } from '../github/github.service';
 import { CacheService } from '../common/cache.service';
+import { sanitizeContributor } from '../common/sanitizers/githubResponseSanitizer';
 
-const CACHE_TTL = 300; // 5 minutes
+const CACHE_TTL = 300;
 
 @Injectable()
 export class ContributorService {
@@ -15,7 +16,7 @@ export class ContributorService {
   constructor(
     private githubService: GithubService,
     private cacheService: CacheService,
-  ) {}
+  ) { }
 
   async getAllContributors() {
     const cacheKey = 'all_contributors';
@@ -25,17 +26,13 @@ export class ContributorService {
     try {
       const orgName = this.githubService.org;
       const contributorsMap = new Map();
-
       const repositories = await this.githubService.getOrgRepos();
 
-      if (repositories.length === 0) {
-        return [];
-      }
+      if (repositories.length === 0) return [];
 
       const BATCH_SIZE = 10;
       for (let i = 0; i < repositories.length; i += BATCH_SIZE) {
         const batch = repositories.slice(i, i + BATCH_SIZE);
-
         await Promise.all(
           batch.map(async (repo) => {
             try {
@@ -46,18 +43,18 @@ export class ContributorService {
               if (!contributors?.length) return;
 
               contributors.forEach((contributor) => {
-                const login = contributor.login.toLowerCase();
+                const clean = sanitizeContributor(contributor);
+                if (!clean) return;
+                const login = clean.login.toLowerCase();
 
                 if (!contributorsMap.has(login)) {
                   contributorsMap.set(login, {
-                    login: contributor.login,
-                    contributions: contributor.contributions,
+                    ...clean,
                     repos: new Set([repo.name]),
-                    avatar_url: contributor.avatar_url,
                   });
                 } else {
                   const userData = contributorsMap.get(login);
-                  userData.contributions += contributor.contributions;
+                  userData.contributions += clean.contributions;
                   userData.repos.add(repo.name);
                 }
               });
@@ -89,13 +86,9 @@ export class ContributorService {
   async getUserCreatedIssues(username: string) {
     try {
       const issues = await this.githubService.searchUserIssues(username);
-
       if (!issues) {
-        throw new InternalServerErrorException(
-          'Failed to fetch user-created issues',
-        );
+        throw new InternalServerErrorException('Failed to fetch user-created issues');
       }
-
       return { issues };
     } catch (error) {
       this.logger.error(
@@ -108,15 +101,10 @@ export class ContributorService {
 
   async getUserCreatedPullRequests(username: string) {
     try {
-      const pullRequests =
-        await this.githubService.searchUserPullRequests(username);
-
+      const pullRequests = await this.githubService.searchUserPullRequests(username);
       if (!pullRequests) {
-        throw new InternalServerErrorException(
-          'Failed to fetch user-created pull requests',
-        );
+        throw new InternalServerErrorException('Failed to fetch user-created pull requests');
       }
-
       return { pullRequests };
     } catch (error) {
       this.logger.error(
@@ -127,17 +115,12 @@ export class ContributorService {
     }
   }
 
-  /**
-   * Combined endpoint: fetches both issues and PRs in parallel.
-   * Saves the frontend from making 2 separate requests.
-   */
   async getUserStats(username: string) {
     try {
       const [issues, pullRequests] = await Promise.all([
         this.githubService.searchUserIssues(username),
         this.githubService.searchUserPullRequests(username),
       ]);
-
       return {
         issues: issues || [],
         pullRequests: pullRequests || [],
@@ -153,17 +136,14 @@ export class ContributorService {
 
   async getUserFollowersAndFollowing(username: string) {
     try {
-      const result =
-        await this.githubService.getUserFollowersAndFollowing(username);
+      const result = await this.githubService.getUserFollowersAndFollowing(username);
       return result;
     } catch (error) {
       this.logger.error(
         'Error fetching user followers and following:',
         error.response ? error.response.data : error.message,
       );
-      throw new InternalServerErrorException(
-        'Failed to fetch followers and following data',
-      );
+      throw new InternalServerErrorException('Failed to fetch followers and following data');
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #547

Introduces a reusable `githubResponseSanitizer.ts` utility that sanitizes 
GitHub API responses before caching and returning to the UI.

## Changes Made

### New File
- `src/common/sanitizers/githubResponseSanitizer.ts`
  - `sanitizeRepository()` — extracts only required repo fields
  - `sanitizeContributor()` — removes email and unnecessary metadata
  - `sanitizeIssue()` — normalizes issue response shape
  - `sanitizePullRequest()` — normalizes PR response shape

### Modified Files
- `src/project/project.service.ts`
  - Applied `sanitizeRepository()` in `getAllProjects()` and `searchProjects()`
  - Applied `sanitizeIssue()` in `getIssuesAndPr()`

- `src/contributor/contributor.service.ts`
  - Applied `sanitizeContributor()` in `getAllContributors()`

## Benefits
- Removes unnecessary metadata before storing in cache
- Consistent response shapes returned to UI
- Centralized sanitization logic — easy to maintain
- Prevents unused fields like email, node_id from being cached