### PR TITLE
fix(ui): center pagination for contributor gallery #382

### DIFF
--- a/webiu-ui/src/app/page/contributors/contributors.component.scss
+++ b/webiu-ui/src/app/page/contributors/contributors.component.scss
@@ -147,7 +147,7 @@
 
   .pagination-container {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     margin-top: 40px;
     margin-bottom: 40px;
@@ -157,7 +157,7 @@
 
     .pagination {
       display: flex;
-      justify-content: flex-start;
+      justify-content: center;
       align-items: center;
       gap: 8px;
       flex: 1;


### PR DESCRIPTION
Fixes #382

## Description
Fixed pagination alignment in Contributor Gallery.
Pagination controls were left-aligned on desktop.

## Changes Made
- Changed justify-content: space-between → center
  in .pagination-container
- Changed justify-content: flex-start → center
  in .pagination

## Files Changed
- webiu-ui/src/app/page/contributors/contributors.component.scss

## Checklist
- [x] Only contributors.component.scss changed
- [x] No backend files modified
- [x] No unrelated frontend changes
- [x] Before/after screenshots attached

BEFORE - 
<img width="950" height="827" alt="image" src="https://github.com/user-attachments/assets/9d8156b8-929d-4ea7-a35b-1ada2096d613" />
<img width="950" height="827" alt="image" src="https://github.com/user-attachments/assets/3af5b6c7-d8f4-4b47-b4b6-d2befab4dcc0" />

AFTER - 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d1a5f3a8-8a6a-454a-9633-242c4da708ee" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/54f1a0f4-28cd-454d-bc00-b72e1889e48c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/09136e23-a6cf-4e2c-9a39-0cf4c19dd5aa" />
