### PR TITLE
fix: apply dark theme variables to search bar on projects page

### DIFF
--- a/webiu-ui/src/app/page/projects/projects.component.scss
+++ b/webiu-ui/src/app/page/projects/projects.component.scss
@@ -182,33 +182,33 @@
   .search-box {
     width: 100%;
     padding: 10px 10px 10px 36px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--select-border);
     border-radius: 8px;
     outline: none;
     margin: 0;
     transition: all 0.3s ease-in-out;
-    background-color: #f9f9f9;
+    background-color: var(--select-bg);
+    color: var(--search-color);
     height: 45px;
     box-sizing: border-box;
 
     &:hover {
       border-color: #bdbdbd;
-      background-color: #f2f2f2;
+      background-color: var(--select-bg);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
     }
 
     &:focus {
       border-color: #3498db;
       box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
-      background-color: #ffffff;
+      background-color: var(--select-bg);
     }
 
     &::placeholder {
-      color: #070202;
+      color: var(--filter-section-color);
       font-style: italic;
     }
   }
-
   .search-icon {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
Closes #557

## Problem
Search bar on /projects had hardcoded light background colors (#f9f9f9, #f2f2f2, #ffffff)
causing it to remain white in dark mode.

## Fix
Replaced hardcoded colors with existing CSS theme variables:
- background-color: var(--select-bg)
- border: var(--select-border)
- color: var(--search-color)
- placeholder: var(--filter-section-color)

## Checklist
- [x] Search bar now follows dark theme
- [x] Light mode unchanged
- [x] Uses existing theme variables from the project

Screenshots
<img width="1919" height="1079" alt="Capture d&#39;écran 2026-03-17 230542" src="https://github.com/user-attachments/assets/932ea5e1-caf4-4689-bd23-88e53a028cf8" />


