### PR TITLE
fix/community-top-contributors-avatar

### DIFF
--- a/webiu-ui/src/app/page/community/community.component.html
+++ b/webiu-ui/src/app/page/community/community.component.html
@@ -34,6 +34,14 @@
           @for (user of users; track $index) {
             <div class="card">
               <div class="card-data">
+                <img
+                  class="user-avatar"
+                  [src]="user.avatar_url || 'https://github.com/' + user.login + '.png'"
+                  [alt]="user.login + ' avatar'"
+                  loading="lazy"
+                  width="72"
+                  height="72"
+                />
                 <a
                   class="user-name"
                   href="https://github.com/{{ user.login }}"

--- a/webiu-ui/src/app/page/community/community.component.scss
+++ b/webiu-ui/src/app/page/community/community.component.scss
@@ -130,6 +130,21 @@
             justify-content: center;
             text-align: center;
 
+            .user-avatar {
+              width: 72px;
+              height: 72px;
+              border-radius: 50%;
+              object-fit: cover;
+              border: 1px solid var(--community-card-border, #e1e4e8);
+              margin-bottom: 10px;
+              background: var(--community-card-bg, #ffffff);
+
+              @media screen and (max-width: 480px) {
+                width: 64px;
+                height: 64px;
+              }
+            }
+
             .user-name {
               font-size: 16px;
               font-weight: 600;


### PR DESCRIPTION
Fixes #563
## Summary
This PR fixes a UI bug on the Community page where Top Contributors cards were missing GitHub profile avatars.

## Problem
On `/community`, contributor cards in the "Top Contributors" section displayed only:
- username
- commit count

No profile image was rendered in light or dark mode.

## Root Cause
The card markup in the Community template did not include an avatar image element, so avatar data from the API was never displayed.

## Fix Implemented
- Added avatar rendering in each contributor card.
- Used available contributor avatar URL with a GitHub image fallback pattern.
- Added avatar styling for consistent circular display, spacing, and responsive sizing.

##screenshoot after fix 
<img width="1152" height="824" alt="Capture d&#39;écran 2026-03-18 054025" src="https://github.com/user-attachments/assets/92ef0489-a692-444b-8fdd-aa6ea12dda45" />

## Files Changed
- [webiu-ui/src/app/page/community/community.component.html
- [webiu-ui/src/app/page/community/community.component.scss]

## Verification
- Confirmed the community component files have no diagnostics errors.
- Verified that contributor cards now display avatars and continue to show username + commit count.

## Impact
- UI-only change, scoped to the Community page.
- No API contract changes.
- No backend changes.