### PR TITLE
Fix: Remove duplicate entries from publications data

### DIFF
--- a/webiu-ui/package-lock.json
+++ b/webiu-ui/package-lock.json
@@ -428,24 +428,6 @@
         }
       }
     },
-    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-eslint/builder/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -657,24 +639,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/cli-cursor": {
@@ -5335,6 +5299,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -6349,24 +6314,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/angular-eslint/node_modules/cli-cursor": {
@@ -16026,6 +15973,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16666,6 +16614,7 @@
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",

--- a/webiu-ui/src/app/page/publications/publications-data.ts
+++ b/webiu-ui/src/app/page/publications/publications-data.ts
@@ -3,68 +3,17 @@ export const publicationsData = [
     heading:
       'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
     link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
+    issued_by: '30th USENIX Security Symposium (USENIX Security 21)',
     description:
       'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
   },
   {
     heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
+      'Malicious and low credibility URLs on Twitter during the AstraZeneca COVID-19 vaccine development',
     link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
     issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
+      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021',
     description:
       'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
   },
 ];


### PR DESCRIPTION
### Fix: Duplicate entries on Publications page

#### Issue:

The publications page displayed duplicate entries due to repeated objects in `publicationsData`.

#### Changes:

* Removed duplicate publication entries
* Ensured only unique publications remain

#### Result:

Publications page now displays clean and non-redundant data.
