### PR TITLE
fix: keep community dropdown open when on opportunities route

### DIFF
--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -29,6 +29,10 @@ export class NavbarComponent implements OnInit {
 
   ngOnInit(): void {
     this.isSunVisible = !this.themeService.isDarkMode();
+    this.currentRoute = this.router.url;
+    this.isCommunityDropdownOpen = 
+      this.currentRoute === '/community' || 
+      this.currentRoute === '/opportunities';
     this.router.events
       .pipe(
         filter(
@@ -37,9 +41,11 @@ export class NavbarComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((event: NavigationEnd) => {
-        this.currentRoute = event.url;
+        this.currentRoute = event.urlAfterRedirects;
         this.isMenuOpen = false;
-        this.isCommunityDropdownOpen = false;
+        this.isCommunityDropdownOpen = 
+          this.currentRoute === '/community' || 
+          this.currentRoute === '/opportunities';
       });
 
     if (isPlatformBrowser(this.platformId)) {
@@ -171,7 +177,10 @@ export class NavbarComponent implements OnInit {
     if (route === '/projects' && this.currentRoute.startsWith('/project')) {
       return true;
     }
-    if (route === '/community' && (this.currentRoute === '/community' || this.currentRoute === '/opportunities')) {
+    if (route === '/community' && (
+      this.currentRoute === '/community' || 
+      this.currentRoute === '/opportunities'
+    )) {
       return true;
     }
     return this.currentRoute === route;


### PR DESCRIPTION
Closes #460

## Problem
Navigating to /opportunities route caused the Community dropdown 
to close, losing the active state context for the Opportunities 
link.

## Fix
- Set isCommunityDropdownOpen to true when current route is 
  /community or /opportunities on NavigationEnd event
- Restore dropdown open state on page reload via router.url check
- Used urlAfterRedirects for accurate route detection

## Checklist
- [x] Opportunities link shows active state when on /opportunities
- [x] Community dropdown stays open on both /community and /opportunities
- [x] Dropdown closes normally on other routes