### PR TITLE
fix: remove duplicate entries on publications page

### DIFF
--- a/webiu-ui/src/app/page/publications/publications-data.ts
+++ b/webiu-ui/src/app/page/publications/publications-data.ts
@@ -1,70 +1,25 @@
-export const publicationsData = [
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
-    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
-    issued_by:
-      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
-    description:
-      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
-  },
-  {
-    heading:
-      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
-    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
-    issued_by: '30th USENIX security symposium (USENIX security 21)',
-    description:
-      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
-  },
-];
+import { Component } from '@angular/core';
+import { NavbarComponent } from '../../components/navbar/navbar.component';
+import { PublicationsCardComponent } from '../../components/publications-card/publications-card.component';
+import { publicationsData } from './publications-data';
+
+@Component({
+  selector: 'app-publications',
+  standalone: true,
+  imports: [NavbarComponent, PublicationsCardComponent],
+  templateUrl: './publications.component.html',
+  styleUrls: ['./publications.component.scss'],
+})
+export class PublicationsComponent {
+  publicationsData = this.deduplicatePublications(publicationsData);
+
+  private deduplicatePublications(data: typeof publicationsData) {
+    const seen = new Set<string>();
+    return data.filter((pub) => {
+      const key = pub.link;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+}

--- a/webiu-ui/src/app/page/publications/publications-data.ts
+++ b/webiu-ui/src/app/page/publications/publications-data.ts
@@ -1,25 +1,19 @@
-import { Component } from '@angular/core';
-import { NavbarComponent } from '../../components/navbar/navbar.component';
-import { PublicationsCardComponent } from '../../components/publications-card/publications-card.component';
-import { publicationsData } from './publications-data';
-
-@Component({
-  selector: 'app-publications',
-  standalone: true,
-  imports: [NavbarComponent, PublicationsCardComponent],
-  templateUrl: './publications.component.html',
-  styleUrls: ['./publications.component.scss'],
-})
-export class PublicationsComponent {
-  publicationsData = this.deduplicatePublications(publicationsData);
-
-  private deduplicatePublications(data: typeof publicationsData) {
-    const seen = new Set<string>();
-    return data.filter((pub) => {
-      const key = pub.link;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
-  }
-}
+export const publicationsData = [
+  {
+    heading:
+      'Compromised or {Attacker-Owned}: A large scale classification and study of hosting domains of malicious {URLs}',
+    link: 'https://www.usenix.org/conference/usenixsecurity21/presentation/desilva',
+    issued_by: '30th USENIX security symposium (USENIX security 21)',
+    description:
+      'Authors: Ravindu De Silva, Mohamed Nabeel, Charith Elvitigala, Issa Khalil, Ting Yu, Chamath Keppitiyagama',
+  },
+  {
+    heading:
+      'Malicious and low credibility urls on twitter during the astrazeneca covid-19 vaccine development',
+    link: 'https://link.springer.com/chapter/10.1007/978-3-030-80387-2_1',
+    issued_by:
+      'Social, Cultural, and Behavioral Modeling - 14th International Conference, SBP-BRiMS 2021, Virtual Event, July 6–9, 2021, Proceedings 14',
+    description:
+      'Authors: Sameera Horawalavithana, Ravindu De Silva, Mohamed Nabeel, Charitha Elvitigala, Primal Wijesekara, Adriana Iamnitchi',
+  },
+];

--- a/webiu-ui/src/app/page/publications/publications.component.ts
+++ b/webiu-ui/src/app/page/publications/publications.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-
 import { NavbarComponent } from '../../components/navbar/navbar.component';
 import { PublicationsCardComponent } from '../../components/publications-card/publications-card.component';
 import { publicationsData } from './publications-data';
@@ -12,5 +11,16 @@ import { publicationsData } from './publications-data';
   styleUrls: ['./publications.component.scss'],
 })
 export class PublicationsComponent {
-  publicationsData = publicationsData;
+  publicationsData = this.deduplicatePublications(publicationsData);
+
+  private deduplicatePublications(
+    data: { heading: string; link: string; issued_by: string; description: string }[]
+  ) {
+    const seen = new Set<string>();
+    return data.filter((pub) => {
+      if (seen.has(pub.link)) return false;
+      seen.add(pub.link);
+      return true;
+    });
+  }
 }


### PR DESCRIPTION
Closes #558

## Problem
Publications page displayed 8 entries when only 2 unique 
publications exist. The publications-data.ts file contained 
the same entries repeated multiple times.

## Fix
- Removed duplicate entries from publications-data.ts
- Added deduplicatePublications() method in component using 
  a Set keyed on publication URL to prevent future duplicates

## Checklist
- [x] Duplicate entries removed from data source
- [x] Deduplication guard added in component
- [x] Publications page renders correctly
