### PR TITLE
fix(cache): replace truthy checks with null checks for falsy cached values

### DIFF
--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -73,7 +73,12 @@ export class CacheService {
     return entry.etag;
   }
 
-  set<T = unknown>(key: string, data: T, ttlSeconds?: number, etag?: string): void {
+  set<T = unknown>(
+    key: string,
+    data: T,
+    ttlSeconds?: number,
+    etag?: string,
+  ): void {
     const ttl = ttlSeconds ?? this.defaultTtl;
     this.cache.set(key, {
       data,

--- a/webiu-server/src/common/dto/username.dto.ts
+++ b/webiu-server/src/common/dto/username.dto.ts
@@ -1,13 +1,13 @@
 import { IsNotEmpty, Matches, MaxLength } from 'class-validator';
 
 export class UsernameDto {
-    @IsNotEmpty({ message: 'Username is required' })
-    @Matches(/^[a-zA-Z0-9_-]+$/, {
-        message:
-            'Username can only contain letters, numbers, hyphens, and underscores',
-    })
-    @MaxLength(39, {
-        message: 'Username cannot exceed 39 characters (GitHub limit)',
-    })
-    username: string;
+  @IsNotEmpty({ message: 'Username is required' })
+  @Matches(/^[a-zA-Z0-9_-]+$/, {
+    message:
+      'Username can only contain letters, numbers, hyphens, and underscores',
+  })
+  @MaxLength(39, {
+    message: 'Username cannot exceed 39 characters (GitHub limit)',
+  })
+  username: string;
 }

--- a/webiu-server/src/contributor/contributor.controller.ts
+++ b/webiu-server/src/contributor/contributor.controller.ts
@@ -7,7 +7,7 @@ import { UsernameDto } from '../common/dto/username.dto';
 // All contributor endpoints: stricter limit — each call fans out to GitHub API
 @Throttle({ default: { ttl: 60_000, limit: 10 } })
 export class ContributorController {
-  constructor(private contributorService: ContributorService) { }
+  constructor(private contributorService: ContributorService) {}
 
   // Most expensive endpoint: fetches contributors for every repo in the org.
   // Tightest limit: 5 requests per IP per minute.

--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -20,7 +20,7 @@ export class ContributorService {
   async getAllContributors() {
     const cacheKey = 'all_contributors';
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const orgName = this.githubService.org;

--- a/webiu-server/src/github/github.graphql.service.ts
+++ b/webiu-server/src/github/github.graphql.service.ts
@@ -45,7 +45,7 @@ export class GithubGraphqlService {
     const cacheKey = `graphql_prs_${normalizedUsername}`;
 
     const cached = this.cacheService.get(cacheKey);
-    if (cached) {
+    if (cached !== null) {
       return cached;
     }
 

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -100,7 +100,7 @@ export class GithubService {
   async getAllOrgReposSorted(): Promise<GithubRepo[]> {
     const cacheKey = `all_org_repos_sorted_${this.orgName}`;
     const cached = this.cacheService.get<GithubRepo[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const repos = await this.fetchAllPages(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
@@ -153,7 +153,7 @@ export class GithubService {
     if (page !== undefined && perPage !== undefined) {
       const cacheKey = `org_repos_${this.orgName}_p${page}_pp${perPage}`;
       const cached = this.cacheService.get<any[]>(cacheKey);
-      if (cached) return cached;
+      if (cached !== null) return cached;
 
       const response = await axios.get(
         `${this.baseUrl}/orgs/${this.orgName}/repos?per_page=${perPage}&page=${page}`,
@@ -166,7 +166,7 @@ export class GithubService {
 
     const cacheKey = `org_repos_${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const repos = await this.fetchAllPages(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
@@ -182,7 +182,7 @@ export class GithubService {
   async getRepo(repoName: string): Promise<GithubRepo | null> {
     const cacheKey = `repo_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<GithubRepo>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -207,7 +207,7 @@ export class GithubService {
   async getCommitActivity(repoName: string): Promise<any[]> {
     const cacheKey = `commit_activity_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -245,7 +245,7 @@ export class GithubService {
   async getParticipationStats(repoName: string): Promise<any[]> {
     const cacheKey = `participation_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -277,7 +277,7 @@ export class GithubService {
   async getLatestRelease(repoName: string): Promise<any | null> {
     const cacheKey = `latest_release_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -302,7 +302,7 @@ export class GithubService {
   async getRepoPulls(repoName: string): Promise<any[]> {
     const cacheKey = `pulls_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const pulls = await this.fetchAllPages(
       `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls?state=all`,
@@ -314,7 +314,7 @@ export class GithubService {
   async getRepoIssues(org: string, repo: string): Promise<any[]> {
     const cacheKey = `issues_${org}_${repo}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const issues = await this.fetchAllPages(
       `${this.baseUrl}/repos/${org}/${repo}/issues`,
@@ -330,7 +330,7 @@ export class GithubService {
   async getRepoLanguages(repoName: string): Promise<Record<string, number>> {
     const cacheKey = `languages_${this.orgName}_${repoName}`;
     const cached = this.cacheService.get<Record<string, number>>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const response = await axios.get(
@@ -350,10 +350,7 @@ export class GithubService {
     }
   }
 
-  async getRepoContributors(
-    orgName: string,
-    repoName: string,
-  ): Promise<any[]> {
+  async getRepoContributors(orgName: string, repoName: string): Promise<any[]> {
     const normalizedOrgName = orgName.toLowerCase();
     const normalizedRepoName = repoName.toLowerCase();
     const cacheKey = `contributors_${normalizedOrgName}_${normalizedRepoName}`;
@@ -380,7 +377,7 @@ export class GithubService {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_issues:${normalizedUsername}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const issues = await this.fetchAllSearchPages(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:issue`,
@@ -393,7 +390,7 @@ export class GithubService {
     const normalizedUsername = username.toLowerCase();
     const cacheKey = `search_prs:${normalizedUsername}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const prs = await this.fetchAllSearchPages(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:pr`,
@@ -440,7 +437,7 @@ export class GithubService {
   async getPublicUserProfile(username: string): Promise<any> {
     const cacheKey = `user_profile_${username}`;
     const cached = this.cacheService.get<any>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const response = await axios.get(`${this.baseUrl}/users/${username}`, {
       headers: this.headers,
@@ -483,7 +480,7 @@ export class GithubService {
       followers: number;
       following: number;
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       // ✅ Correct source of truth: GitHub profile fields (not list endpoints capped at 30)
@@ -514,7 +511,7 @@ export class GithubService {
     const normalizedQuery = query.toLowerCase();
     const cacheKey = `search_repos:${normalizedQuery}:${this.orgName}`;
     const cached = this.cacheService.get<any[]>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     const encoded = encodeURIComponent(query);
     const repos = await this.fetchAllSearchPages(

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -39,7 +39,7 @@ export class ProjectService {
       limit: number;
       repositories: any[];
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const allRepos = await this.githubService.getAllOrgReposSorted();
@@ -69,7 +69,7 @@ export class ProjectService {
 
     const cacheKey = `issues_pr_count_${org}_${repo}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const data = await this.githubService.getRepoIssues(org, repo);
@@ -101,7 +101,7 @@ export class ProjectService {
 
     const cacheKey = `project_details_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       // Direct fetch of a single repo as requested by maintainers
@@ -152,7 +152,7 @@ export class ProjectService {
 
     const cacheKey = `project_insights_v2_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const [project, activity, release, languages] = await Promise.all([
@@ -281,7 +281,7 @@ export class ProjectService {
 
     const cacheKey = `project_contributors_enriched_${name}`;
     const cached = this.cacheService.get(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const [contributors, pulls, issues] = await Promise.all([
@@ -345,7 +345,7 @@ export class ProjectService {
       limit: number;
       repositories: any[];
     }>(cacheKey);
-    if (cached) return cached;
+    if (cached !== null) return cached;
 
     try {
       const allRepos = await this.githubService.getAllOrgReposSorted();

--- a/webiu-server/src/user/user.controller.ts
+++ b/webiu-server/src/user/user.controller.ts
@@ -5,7 +5,7 @@ import { UsernameDto } from '../common/dto/username.dto';
 
 @Controller('api/v1/user')
 export class UserController {
-  constructor(private userService: UserService) { }
+  constructor(private userService: UserService) {}
 
   @Get('followersAndFollowing/:username')
   async getFollowersAndFollowing(@Param() params: UsernameDto) {

--- a/webiu-server/src/user/user.validation.spec.ts
+++ b/webiu-server/src/user/user.validation.spec.ts
@@ -6,76 +6,83 @@ import { UserService } from './user.service';
 import { GithubService } from '../github/github.service';
 
 describe('UserController (Validation)', () => {
-    let app: INestApplication;
-    const mockUserService = {
-        getFollowersAndFollowing: jest.fn(),
-        getUserProfile: jest.fn(),
-    };
-    const mockGithubService = {};
+  let app: INestApplication;
+  const mockUserService = {
+    getFollowersAndFollowing: jest.fn(),
+    getUserProfile: jest.fn(),
+  };
+  const mockGithubService = {};
 
-    beforeAll(async () => {
-        const moduleFixture: TestingModule = await Test.createTestingModule({
-            imports: [UserModule],
-        })
-            .overrideProvider(UserService)
-            .useValue(mockUserService)
-            .overrideProvider(GithubService)
-            .useValue(mockGithubService)
-            .compile();
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [UserModule],
+    })
+      .overrideProvider(UserService)
+      .useValue(mockUserService)
+      .overrideProvider(GithubService)
+      .useValue(mockGithubService)
+      .compile();
 
-        app = moduleFixture.createNestApplication();
-        app.useGlobalPipes(
-            new ValidationPipe({
-                whitelist: true,
-                transform: true,
-            }),
-        );
-        await app.init();
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /api/v1/user/followersAndFollowing/:username', () => {
+    it('should return 200 for valid username', () => {
+      mockUserService.getFollowersAndFollowing.mockReturnValue({
+        followers: [],
+        following: [],
+      });
+      return request(app.getHttpServer())
+        .get('/api/v1/user/followersAndFollowing/valid-user_123')
+        .expect(200);
     });
 
-    afterAll(async () => {
-        await app.close();
-    });
-
-    describe('GET /api/v1/user/followersAndFollowing/:username', () => {
-        it('should return 200 for valid username', () => {
-            mockUserService.getFollowersAndFollowing.mockReturnValue({ followers: [], following: [] });
-            return request(app.getHttpServer())
-                .get('/api/v1/user/followersAndFollowing/valid-user_123')
-                .expect(200);
-        });
-
-        it('should return 400 for username with special characters', () => {
-            return request(app.getHttpServer())
-                .get('/api/v1/user/followersAndFollowing/invalid@user')
-                .expect(400)
-                .expect((res) => {
-                    expect(res.body.message).toContain('Username can only contain letters, numbers, hyphens, and underscores');
-                });
-        });
-
-        it('should return 400 for too long username', () => {
-            return request(app.getHttpServer())
-                .get('/api/v1/user/followersAndFollowing/' + 'a'.repeat(40))
-                .expect(400)
-                .expect((res) => {
-                    expect(res.body.message).toContain('Username cannot exceed 39 characters (GitHub limit)');
-                });
+    it('should return 400 for username with special characters', () => {
+      return request(app.getHttpServer())
+        .get('/api/v1/user/followersAndFollowing/invalid@user')
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.message).toContain(
+            'Username can only contain letters, numbers, hyphens, and underscores',
+          );
         });
     });
 
-    describe('GET /api/v1/user/profile/:username', () => {
-        it('should return 200 for valid username', () => {
-            mockUserService.getUserProfile.mockReturnValue({ name: 'Valid User' });
-            return request(app.getHttpServer())
-                .get('/api/v1/user/profile/valid-user')
-                .expect(200);
-        });
-
-        it('should return 400 for invalid username', () => {
-            return request(app.getHttpServer())
-                .get('/api/v1/user/profile/invalid.user')
-                .expect(400);
+    it('should return 400 for too long username', () => {
+      return request(app.getHttpServer())
+        .get('/api/v1/user/followersAndFollowing/' + 'a'.repeat(40))
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.message).toContain(
+            'Username cannot exceed 39 characters (GitHub limit)',
+          );
         });
     });
+  });
+
+  describe('GET /api/v1/user/profile/:username', () => {
+    it('should return 200 for valid username', () => {
+      mockUserService.getUserProfile.mockReturnValue({ name: 'Valid User' });
+      return request(app.getHttpServer())
+        .get('/api/v1/user/profile/valid-user')
+        .expect(200);
+    });
+
+    it('should return 400 for invalid username', () => {
+      return request(app.getHttpServer())
+        .get('/api/v1/user/profile/invalid.user')
+        .expect(400);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #538

## Summary
Replaces truthy cache-hit checks with explicit `null` checks across all 
backend service files. Previously, `if (cached)` would incorrectly treat 
valid falsy values (empty arrays `[]`, `0`, `false`) as cache misses and 
trigger unnecessary GitHub API calls.

## Changes
- `github/github.service.ts` — fixed 14 occurrences
- `project/project.service.ts` — fixed 6 occurrences  
- `contributor/contributor.service.ts` — fixed 1 occurrence
- `github/github.graphql.service.ts` — fixed 1 occurrence

## Why This Matters
When a user has no issues or PRs, the cache correctly stores an empty 
array `[]`. With the old truthy check, `if ([])` evaluates as truthy 
BUT `if (cached)` where cached is `[]` evaluates as... actually truthy.
The real problem is values like `0` (PR count), `false`, or `""` which 
are valid cached results but get treated as misses.

## Testing
- `npm run lint` ✅
- `npm test` — 99/99 tests passed, 12 suites ✅