### PR TITLE
fix: prevent dark theme flash on page load (FOUC)

### DIFF
--- a/webiu-ui/src/index.html
+++ b/webiu-ui/src/index.html
@@ -2,6 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
+    <script>
+      (function() {
+        try {
+          var isDark = localStorage.getItem('dark-mode') === 'true';
+          if (isDark) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <title>Webiu</title>
     <base href="/"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>


### PR DESCRIPTION
Closes #515

## Problem
Users with dark mode enabled experienced a white flash 
on page load before Angular initialized and applied 
the dark theme.

## Root Cause
ThemeService applied data-theme in the Angular constructor,
which runs after the browser has already rendered the page.

## Fix
Added an inline script in index.html <head> that reads 
localStorage before any rendering occurs and immediately 
sets data-theme="dark" if needed. This is the standard 
anti-FOUC technique used by major frameworks.

## Checklist
- [x] No flash on page load in dark mode
- [x] Light mode unaffected
- [x] try/catch protects against SSR and private browsing
- [x] ThemeService constructor logic preserved as fallback