### PR TITLE
fix(server): add startup env validation for required variables

### DIFF
--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -11,7 +11,8 @@ MONGODB_URI=
 # ==============================
 # JWT Authentication
 # ==============================
-JWT_SECRET=your_jwt_secret
+# Must be at least 15 characters. No leading/trailing spaces.
+JWT_SECRET=your_jwt_secret_here
 
 # ==============================
 # Frontend
@@ -46,5 +47,8 @@ CACHE_TTL_SECONDS=300
 # ==============================
 # GitHub API Access Token
 # (Used for fetching repos, contributors, issues, PRs)
+# Generate at: https://github.com/settings/tokens (no scopes needed for public data)
+# WARNING: No leading/trailing spaces — the token must start immediately after the =
+# Example of WRONG format: GITHUB_ACCESS_TOKEN= ghp_abc  ← space will cause 401 errors
 # ==============================
 GITHUB_ACCESS_TOKEN=

--- a/webiu-server/src/main.ts
+++ b/webiu-server/src/main.ts
@@ -5,7 +5,36 @@ import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
 import * as compression from 'compression';
 
+function validateEnv(): void {
+  const errors: string[] = [];
+  const githubToken = (process.env.GITHUB_ACCESS_TOKEN ?? '').trim();
+  if (!githubToken) {
+    errors.push(
+      'GITHUB_ACCESS_TOKEN is missing, please do generate one from github token settings.',
+    );
+  }
+  const jwtSecret = (process.env.JWT_SECRET ?? '').trim();
+  if (!jwtSecret) {
+    errors.push(
+      'JWT_SECRET is missing, please set a strong secret string for JWT token',
+    );
+  } else if (jwtSecret.length < 15) {
+    errors.push(
+      'JWT_SECRET should be at least 15 characters long for better security',
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error(
+      '\nServer startup failed — missing or invalid environment variables:',
+    );
+    errors.forEach((error) => console.error(`  • ${error}`));
+    process.exit(1);
+  }
+}
+
 async function bootstrap() {
+  validateEnv();
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
 


### PR DESCRIPTION

## Problem

The server starts successfully even when `GITHUB_ACCESS_TOKEN` or `JWT_SECRET`
are missing or malformed in `.env`. This causes silent failures at runtime —
for example, a leading space in `GITHUB_ACCESS_TOKEN= ghp_abc` causes all
GitHub API calls to return 401 errors with no clear indication of the root cause.

## Fix : #588 
<img width="1226" height="647" alt="validateenv" src="https://github.com/user-attachments/assets/f8bc7a20-d2f6-4722-8c54-48d032badbfd" />

Adds a `validateEnv()` function in `main.ts` that runs **before** the NestJS
app is created. It checks that required env variables are present and valid,
then exits immediately with a clear error message if not.

**Example output when token is missing:**
<img width="1416" height="223" alt="error" src="https://github.com/user-attachments/assets/a662d28b-e90f-4793-b204-6de26032f0d8" />

Server startup failed — missing or invalid environment variables:
• GITHUB_ACCESS_TOKEN is missing, please generate one from github token settings.



Also updates `.env.example` with warnings about leading/trailing spaces and
minimum length requirements for `JWT_SECRET`.

## Changes

- `webiu-server/src/main.ts` — adds `validateEnv()` with fail-fast behaviour
- `webiu-server/.env.example` — adds comments warning about whitespace and secret length

## Testing

**Automated:**
- All 72 existing backend tests pass (`npm test`)
- No new tests broken by this change
<img width="648" height="309" alt="image" src="https://github.com/user-attachments/assets/972d23ce-b089-46b1-8096-4d8c6e70dc00" />


**Manual:**
1. Remove `GITHUB_ACCESS_TOKEN` from `.env` → run `npm start`
   → server should refuse to start with a clear error message
2. Set `JWT_SECRET` to less than 15 characters → run `npm start`
   → server should refuse to start with a clear error message  
3. Restore valid values → run `npm start`
   → server starts normally on port 5050

