### PR TITLE
fix: update README clone URL to official repository (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You will also need a **GitHub Personal Access Token** for the backend to call th
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/rajutkarsh07/Webiu.git
+git clone https://github.com/c2siorg/Webiu.git
 cd Webiu
 ```
 


### PR DESCRIPTION
## Summary
Fixes #483

## Problem
README.md had an incorrect clone URL pointing to a fork 
(`rajutkarsh07/Webiu`) instead of the official repository.

## Fix
Updated clone URL to point to the official C2SI repository.

**Before:** `git clone https://github.com/rajutkarsh07/Webiu.git`
**After:** `git clone https://github.com/c2siorg/Webiu.git`

## Changes
- `README.md` — 1 line changed