### PR TITLE
feat: enforce cache layer type safety

### DIFF
--- a/webiu-server/src/common/cache.service.spec.ts
+++ b/webiu-server/src/common/cache.service.spec.ts
@@ -1,4 +1,5 @@
 import { CacheService } from './cache.service';
+import { CacheKey } from './cache.types';
 
 function mockConfig(ttl?: string) {
   return { get: jest.fn().mockReturnValue(ttl) } as any;
@@ -11,42 +12,59 @@ describe('CacheService', () => {
     service = new CacheService(mockConfig());
   });
 
+  const validKey: CacheKey = 'user_social:test';
+  const validValue = { followers: 10, following: 5 };
+
+  const validKey2: CacheKey = 'all_contributors';
+  const validValue2 = [
+    { login: 'test', contributions: 1, repos: [], avatar_url: '' },
+  ];
+
+  const nonexistentKey: CacheKey = 'user_social:missing';
+
   it('should store and retrieve values', () => {
-    service.set('key', 'value', 60);
-    expect(service.get('key')).toBe('value');
+    service.set(validKey, validValue, 60);
+    expect(service.get(validKey)).toEqual(validValue);
   });
 
   it('should return null for missing keys', () => {
-    expect(service.get('nonexistent')).toBeNull();
+    expect(service.get(nonexistentKey)).toBeNull();
   });
 
   it('should return null for expired entries', async () => {
-    service.set('key', 'value', 1); // expires in 1 second
-    expect(service.get('key')).toBe('value');
+    service.set(validKey, validValue, 1); // expires in 1 second
+    expect(service.get(validKey)).toEqual(validValue);
 
     // Wait for expiry
     await new Promise((resolve) => setTimeout(resolve, 1100));
-    expect(service.get('key')).toBeNull();
+    expect(service.get(validKey)).toBeNull();
   });
 
   it('should delete a specific key', () => {
-    service.set('key', 'value', 60);
-    service.delete('key');
-    expect(service.get('key')).toBeNull();
+    service.set(validKey, validValue, 60);
+    service.delete(validKey);
+    expect(service.get(validKey)).toBeNull();
   });
 
   it('should clear all entries', () => {
-    service.set('key1', 'value1', 60);
-    service.set('key2', 'value2', 60);
+    service.set(validKey, validValue, 60);
+    service.set(validKey2, validValue2, 60);
     service.clear();
-    expect(service.get('key1')).toBeNull();
-    expect(service.get('key2')).toBeNull();
+    expect(service.get(validKey)).toBeNull();
+    expect(service.get(validKey2)).toBeNull();
   });
 
   it('should handle complex objects', () => {
-    const data = { repos: [{ name: 'repo1' }], count: 5 };
-    service.set('complex', data, 60);
-    expect(service.get('complex')).toEqual(data);
+    const data = [
+      {
+        login: 'user1',
+        contributions: 10,
+        repos: ['repo1'],
+        avatar_url: 'url',
+      },
+    ];
+    service.set('all_contributors', data, 60);
+    expect(service.get('all_contributors')).toEqual(data);
   });
 
   describe('TTL configuration', () => {
@@ -64,11 +82,11 @@ describe('CacheService', () => {
         .mockReturnValueOnce(now + 61_000);
 
       const s = new CacheService(mockConfig('60'));
-      s.set('key', 'value');
-      expect(s.get('key')).toBe('value');
+      s.set(validKey, validValue);
+      expect(s.get(validKey)).toEqual(validValue);
 
-      s.set('key2', 'value2');
-      expect(s.get('key2')).toBeNull();
+      s.set(validKey2, validValue2);
+      expect(s.get(validKey2)).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is missing', () => {
@@ -79,8 +97,8 @@ describe('CacheService', () => {
         .mockReturnValueOnce(now + 301_000);
 
       const s = new CacheService(mockConfig(undefined));
-      s.set('key', 'value');
-      expect(s.get('key')).toBeNull();
+      s.set(validKey, validValue);
+      expect(s.get(validKey)).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is invalid (NaN)', () => {
@@ -91,8 +109,8 @@ describe('CacheService', () => {
         .mockReturnValueOnce(now + 301_000);
 
       const s = new CacheService(mockConfig('abc'));
-      s.set('key', 'value');
-      expect(s.get('key')).toBeNull();
+      s.set(validKey, validValue);
+      expect(s.get(validKey)).toBeNull();
     });
 
     it('should fall back to 300s when CACHE_TTL_SECONDS is zero or negative', () => {
@@ -103,8 +121,8 @@ describe('CacheService', () => {
         .mockReturnValueOnce(now + 301_000);
 
       const s = new CacheService(mockConfig('0'));
-      s.set('key', 'value');
-      expect(s.get('key')).toBeNull();
+      s.set(validKey, validValue);
+      expect(s.get(validKey)).toBeNull();
     });
 
     it('should use defaultTtl when set() is called without explicit ttlSeconds', () => {
@@ -117,11 +135,11 @@ describe('CacheService', () => {
         .mockReturnValueOnce(now + 121_000);
 
       const s = new CacheService(mockConfig('120'));
-      s.set('key', 'value');
-      expect(s.get('key')).toBe('value');
+      s.set(validKey, validValue);
+      expect(s.get(validKey)).toEqual(validValue);
 
-      s.set('key2', 'value2');
-      expect(s.get('key2')).toBeNull();
+      s.set(validKey2, validValue2);
+      expect(s.get(validKey2)).toBeNull();
     });
   });
 });

--- a/webiu-server/src/common/cache.service.ts
+++ b/webiu-server/src/common/cache.service.ts
@@ -1,15 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-
-interface CacheEntry<T> {
-  data: T;
-  expiresAt: number;
-}
+import { CacheEntry, CacheKey, CacheValue } from './cache.types';
 
 @Injectable()
 export class CacheService {
   private readonly logger = new Logger(CacheService.name);
-  private cache = new Map<string, CacheEntry<any>>();
+  private cache = new Map<string, CacheEntry<unknown>>();
   private readonly defaultTtl: number;
 
   constructor(private configService: ConfigService) {
@@ -27,7 +23,7 @@ export class CacheService {
     }
   }
 
-  get<T>(key: string): T | null {
+  get<K extends CacheKey>(key: K): CacheValue<K> | null {
     const entry = this.cache.get(key);
     if (!entry) return null;
 
@@ -36,10 +32,14 @@ export class CacheService {
       return null;
     }
 
-    return entry.data as T;
+    return entry.data as CacheValue<K>;
   }
 
-  set<T>(key: string, data: T, ttlSeconds?: number): void {
+  set<K extends CacheKey>(
+    key: K,
+    data: CacheValue<K>,
+    ttlSeconds?: number,
+  ): void {
     const ttl = ttlSeconds ?? this.defaultTtl;
     this.cache.set(key, {
       data,
@@ -47,7 +47,7 @@ export class CacheService {
     });
   }
 
-  delete(key: string): void {
+  delete(key: CacheKey): void {
     this.cache.delete(key);
   }
 

--- a/webiu-server/src/common/cache.types.ts
+++ b/webiu-server/src/common/cache.types.ts
@@ -1,0 +1,132 @@
+export type CacheKey =
+  | `org_repos_${string}`
+  | `pulls_${string}_${string}`
+  | `issues_${string}_${string}`
+  | `contributors_${string}_${string}`
+  | `search_issues:${string}:${string}`
+  | `search_prs:${string}:${string}`
+  | `user_profile_${string}`
+  | `user_social:${string}`
+  | `projects_p${number}_pp${number}`
+  | `issues_pr_count_${string}_${string}`
+  | `projects_search_${string}`
+  | `search_repos:${string}:${string}`
+  | 'all_contributors';
+
+export interface GithubAbstractUser {
+  login: string;
+  id: number;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+}
+
+export interface GithubIssue {
+  id: number;
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  user: GithubAbstractUser;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  html_url: string;
+  body?: string;
+  pull_request?: {
+    url: string;
+    html_url: string;
+    diff_url: string;
+    patch_url: string;
+  };
+}
+
+export interface GithubPullRequest extends GithubIssue {
+  merged_at: string | null;
+  draft?: boolean;
+}
+
+export interface GithubRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  html_url: string;
+  description: string | null;
+  stargazers_count: number;
+  language: string | null;
+}
+
+export interface GithubContributor extends GithubAbstractUser {
+  contributions: number;
+}
+
+export interface GithubUserProfile extends GithubAbstractUser {
+  name: string | null;
+  company: string | null;
+  blog: string;
+  location: string | null;
+  email: string | null;
+  bio: string | null;
+  public_repos: number;
+  followers: number;
+  following: number;
+}
+
+export interface GithubOauthResponse {
+  access_token?: string;
+  scope?: string;
+  token_type?: string;
+  error?: string;
+  error_description?: string;
+  error_uri?: string;
+}
+
+export type CacheValue<K extends CacheKey> = K extends `org_repos_${string}`
+  ? GithubRepo[]
+  : K extends `pulls_${string}`
+    ? GithubPullRequest[]
+    : K extends `issues_pr_count_${string}_${string}`
+      ? { issues: number; pullRequests: number }
+      : K extends `issues_${string}`
+        ? GithubIssue[]
+        : K extends `contributors_${string}`
+          ? GithubContributor[]
+          : K extends `search_issues:${string}`
+            ? GithubIssue[]
+            : K extends `search_prs:${string}`
+              ? GithubPullRequest[]
+              : K extends `user_profile_${string}`
+                ? GithubUserProfile
+                : K extends `user_social:${string}`
+                  ? { followers: number; following: number }
+                  : K extends `projects_p${number}_pp${number}`
+                    ? {
+                        total: number;
+                        page: number;
+                        limit: number;
+                        repositories: (GithubRepo & {
+                          pull_requests: number;
+                        })[];
+                      }
+                    : K extends 'all_contributors'
+                      ? {
+                          login: string;
+                          contributions: number;
+                          repos: string[];
+                          avatar_url: string;
+                        }[]
+                      : K extends `projects_search_${string}`
+                        ? {
+                            total: number;
+                            repositories: (GithubRepo & {
+                              pull_requests: number;
+                            })[];
+                          }
+                        : K extends `search_repos:${string}`
+                          ? GithubRepo[]
+                          : never;
+
+export interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}

--- a/webiu-server/src/contributor/contributor.service.spec.ts
+++ b/webiu-server/src/contributor/contributor.service.spec.ts
@@ -65,7 +65,7 @@ describe('ContributorService', () => {
           { login: 'user2', contributions: 5, avatar_url: 'url2' },
         ]);
 
-      const result = (await service.getAllContributors()) as any[];
+      const result = await service.getAllContributors();
 
       expect(result).toHaveLength(2);
       const user1 = result.find((c) => c.login === 'user1');

--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -18,7 +18,7 @@ export class ContributorService {
   ) {}
 
   async getAllContributors() {
-    const cacheKey = 'all_contributors';
+    const cacheKey = 'all_contributors' as const;
     const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -1,6 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../common/cache.service';
+import {
+  GithubRepo,
+  GithubPullRequest,
+  GithubIssue,
+  GithubContributor,
+  GithubUserProfile,
+  GithubOauthResponse,
+} from '../common/cache.types';
 import axios from 'axios';
 
 const CACHE_TTL = 300; // 5 minutes
@@ -29,8 +37,8 @@ export class GithubService {
     return this.orgName;
   }
 
-  private async fetchAllPages(url: string): Promise<any[]> {
-    const results: any[] = [];
+  private async fetchAllPages<T>(url: string): Promise<T[]> {
+    const results: T[] = [];
     let page = 1;
 
     while (true) {
@@ -52,8 +60,8 @@ export class GithubService {
     return results;
   }
 
-  private async fetchAllSearchPages(url: string): Promise<any[]> {
-    const results: any[] = [];
+  private async fetchAllSearchPages<T>(url: string): Promise<T[]> {
+    const results: T[] = [];
     let page = 1;
 
     while (true) {
@@ -75,12 +83,13 @@ export class GithubService {
     return results;
   }
 
-  async getOrgRepos(): Promise<any[]>;
-  async getOrgRepos(page: number, perPage: number): Promise<any[]>;
-  async getOrgRepos(page?: number, perPage?: number): Promise<any[]> {
+  async getOrgRepos(): Promise<GithubRepo[]>;
+  async getOrgRepos(page: number, perPage: number): Promise<GithubRepo[]>;
+  async getOrgRepos(page?: number, perPage?: number): Promise<GithubRepo[]> {
     if (page !== undefined && perPage !== undefined) {
-      const cacheKey = `org_repos_${this.orgName}_p${page}_pp${perPage}`;
-      const cached = this.cacheService.get<any[]>(cacheKey);
+      const cacheKey =
+        `org_repos_${this.orgName}_p${page}_pp${perPage}` as const;
+      const cached = this.cacheService.get(cacheKey);
       if (cached) return cached;
 
       const response = await axios.get(
@@ -92,35 +101,35 @@ export class GithubService {
       return repos;
     }
 
-    const cacheKey = `org_repos_${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cacheKey = `org_repos_${this.orgName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const repos = await this.fetchAllPages(
+    const repos = await this.fetchAllPages<GithubRepo>(
       `${this.baseUrl}/orgs/${this.orgName}/repos`,
     );
     this.cacheService.set(cacheKey, repos);
     return repos;
   }
 
-  async getRepoPulls(repoName: string): Promise<any[]> {
-    const cacheKey = `pulls_${this.orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+  async getRepoPulls(repoName: string): Promise<GithubPullRequest[]> {
+    const cacheKey = `pulls_${this.orgName}_${repoName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const pulls = await this.fetchAllPages(
+    const pulls = await this.fetchAllPages<GithubPullRequest>(
       `${this.baseUrl}/repos/${this.orgName}/${repoName}/pulls`,
     );
     this.cacheService.set(cacheKey, pulls);
     return pulls;
   }
 
-  async getRepoIssues(org: string, repo: string): Promise<any[]> {
-    const cacheKey = `issues_${org}_${repo}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+  async getRepoIssues(org: string, repo: string): Promise<GithubIssue[]> {
+    const cacheKey = `issues_${org}_${repo}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const issues = await this.fetchAllPages(
+    const issues = await this.fetchAllPages<GithubIssue>(
       `${this.baseUrl}/repos/${org}/${repo}/issues`,
     );
     this.cacheService.set(cacheKey, issues);
@@ -130,13 +139,13 @@ export class GithubService {
   async getRepoContributors(
     orgName: string,
     repoName: string,
-  ): Promise<any[] | null> {
-    const cacheKey = `contributors_${orgName}_${repoName}`;
-    const cached = this.cacheService.get<any[] | null>(cacheKey);
+  ): Promise<GithubContributor[] | null> {
+    const cacheKey = `contributors_${orgName}_${repoName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached !== null) return cached;
 
     try {
-      const contributors = await this.fetchAllPages(
+      const contributors = await this.fetchAllPages<GithubContributor>(
         `${this.baseUrl}/repos/${orgName}/${repoName}/contributors`,
       );
       this.cacheService.set(cacheKey, contributors);
@@ -146,26 +155,28 @@ export class GithubService {
     }
   }
 
-  async searchUserIssues(username: string): Promise<any[]> {
+  async searchUserIssues(username: string): Promise<GithubIssue[]> {
     const normalizedUsername = username.toLowerCase();
-    const cacheKey = `search_issues:${normalizedUsername}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cacheKey =
+      `search_issues:${normalizedUsername}:${this.orgName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const issues = await this.fetchAllSearchPages(
+    const issues = await this.fetchAllSearchPages<GithubIssue>(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:issue`,
     );
     this.cacheService.set(cacheKey, issues);
     return issues;
   }
 
-  async searchUserPullRequests(username: string): Promise<any[]> {
+  async searchUserPullRequests(username: string): Promise<GithubPullRequest[]> {
     const normalizedUsername = username.toLowerCase();
-    const cacheKey = `search_prs:${normalizedUsername}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cacheKey =
+      `search_prs:${normalizedUsername}:${this.orgName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const prs = await this.fetchAllSearchPages(
+    const prs = await this.fetchAllSearchPages<GithubPullRequest>(
       `${this.baseUrl}/search/issues?q=author:${username}+org:${this.orgName}+type:pr`,
     );
 
@@ -200,16 +211,16 @@ export class GithubService {
     return enrichedPrs;
   }
 
-  async getUserInfo(accessToken: string): Promise<any> {
+  async getUserInfo(accessToken: string): Promise<GithubUserProfile> {
     const response = await axios.get(`${this.baseUrl}/user`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     return response.data;
   }
 
-  async getPublicUserProfile(username: string): Promise<any> {
-    const cacheKey = `user_profile_${username}`;
-    const cached = this.cacheService.get<any>(cacheKey);
+  async getPublicUserProfile(username: string): Promise<GithubUserProfile> {
+    const cacheKey = `user_profile_${username}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     const response = await axios.get(`${this.baseUrl}/users/${username}`, {
@@ -224,7 +235,7 @@ export class GithubService {
     clientSecret: string,
     code: string,
     redirectUri: string,
-  ): Promise<any> {
+  ): Promise<GithubOauthResponse> {
     const response = await axios.post(
       'https://github.com/login/oauth/access_token',
       new URLSearchParams({
@@ -247,11 +258,8 @@ export class GithubService {
     following: number;
   }> {
     const normalizedUsername = username.toLowerCase();
-    const cacheKey = `user_social:${normalizedUsername}`;
-    const cached = this.cacheService.get<{
-      followers: number;
-      following: number;
-    }>(cacheKey);
+    const cacheKey = `user_social:${normalizedUsername}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -280,13 +288,13 @@ export class GithubService {
     }
   }
 
-  async searchOrgRepos(query: string): Promise<any[]> {
+  async searchOrgRepos(query: string): Promise<GithubRepo[]> {
     const normalizedQuery = query.toLowerCase();
-    const cacheKey = `search_repos:${normalizedQuery}:${this.orgName}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cacheKey = `search_repos:${normalizedQuery}:${this.orgName}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
-    const repos = await this.fetchAllSearchPages(
+    const repos = await this.fetchAllSearchPages<GithubRepo>(
       `${this.baseUrl}/search/repositories?q=${query}+org:${this.orgName}`,
     );
 

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -19,13 +19,8 @@ export class ProjectService {
   ) {}
 
   async getAllProjects(page = 1, limit = 10) {
-    const cacheKey = `projects_p${page}_pp${limit}`;
-    const cached = this.cacheService.get<{
-      total: number;
-      page: number;
-      limit: number;
-      repositories: any[];
-    }>(cacheKey);
+    const cacheKey = `projects_p${page}_pp${limit}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -76,7 +71,7 @@ export class ProjectService {
       throw new BadRequestException('Organization and repository are required');
     }
 
-    const cacheKey = `issues_pr_count_${org}_${repo}`;
+    const cacheKey = `issues_pr_count_${org}_${repo}` as const;
     const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
@@ -103,8 +98,8 @@ export class ProjectService {
       throw new BadRequestException('Search query is required');
     }
 
-    const cacheKey = `projects_search_${query}`;
-    const cached = this.cacheService.get<any[]>(cacheKey);
+    const cacheKey = `projects_search_${query}` as const;
+    const cached = this.cacheService.get(cacheKey);
     if (cached) return cached;
 
     try {
@@ -121,12 +116,14 @@ export class ProjectService {
         }),
       );
 
-      this.cacheService.set(cacheKey, repositoriesWithPRs, CACHE_TTL);
-
-      return {
+      const result = {
         total: repositoriesWithPRs.length,
         repositories: repositoriesWithPRs,
       };
+
+      this.cacheService.set(cacheKey, result, CACHE_TTL);
+
+      return result;
     } catch (error) {
       this.logger.error(
         'Error searching repositories:',


### PR DESCRIPTION
## Description

This Pull Request overhauls the internal typing mechanics of `CacheService` and related logic.
- Eliminated `any` type usage inside cache services and GitHub module interactions, securing return types like `Promise<GithubRepo[]>` natively.
- Refactored dynamically inferred values in `cache.types.ts`.
- Brought back Explicit Generic definitions for Github/Project/Contributor payloads.
- Extracted inline Github OAuth types into a proper `GithubOauthResponse` interface for cleaner architecture.
- Forced `as const` string mapping validation on `cacheKey` literals to make caching highly predictable.
- Updated `fetchAllSearchPages` and `fetchAllPages` loops inside Github service to maintain correct generic Typescript constraints `<T>`.
- Updated unit tests in `cache.service.spec.ts` and `contributor.service.spec.ts` to natively utilize the new strict mock properties without relying on `any`.

Fixes #592 

## Type of change

- [x] New feature (non-breaking change which adds functionality or refactors logic natively)

## How Has This Been Tested?

- [x] Tested compilation (`npm run build`).
- [x] Checked Linter validity (`npm run lint`).
- [x] Verified overall system interactions against API fetch calls locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
