### PR TITLE
fix: handle github 202 accepted response properly

### DIFF
--- a/webiu-server/src/github/github.service.spec.ts
+++ b/webiu-server/src/github/github.service.spec.ts
@@ -76,6 +76,63 @@ describe('GithubService', () => {
       mockedAxios.get.mockRejectedValue(new Error('API error'));
       await expect(service.getOrgRepos()).rejects.toThrow('API error');
     });
+
+    it('should handle 202 Accepted and retry (202 -> 200)', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          status: 202,
+          headers: { 'retry-after': '1' },
+          data: {},
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          headers: {},
+          data: [{ name: 'repo-after-retry' }],
+        });
+
+      const result = await service.getOrgRepos(1, 10);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('repo-after-retry');
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw 503 Service Unavailable on persistent 202', async () => {
+      mockedAxios.get.mockResolvedValue({
+        status: 202,
+        headers: { 'retry-after': '1' },
+        data: {},
+      });
+
+      await expect(service.getOrgRepos(1, 10)).rejects.toThrow(
+        'GitHub background computation is still processing. Please retry later.',
+      );
+      // It should try initially + maxApiRetries (2) = 3 times
+      expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle bad or missing Retry-After header by using default delay', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          status: 202,
+          headers: { 'retry-after': 'invalid-date' }, // bad Retry-After
+          data: {},
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          headers: {},
+          data: [{ name: 'repo-after-bad-retry' }],
+        });
+
+      const startTime = Date.now();
+      const result = await service.getOrgRepos(1, 10);
+      const duration = Date.now() - startTime;
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('repo-after-bad-retry');
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+      // Default delay is 2500ms
+      expect(duration).toBeGreaterThanOrEqual(2500);
+    });
   });
 
   describe('getRepoPulls', () => {

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../common/cache.service';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 const CACHE_TTL = 300; // 5 minutes
 
@@ -11,6 +11,10 @@ export class GithubService {
   private readonly baseUrl = 'https://api.github.com';
   private readonly accessToken: string;
   private readonly orgName = 'c2siorg';
+
+  // Background computation retry parameters
+  private readonly maxApiRetries = 2;
+  private readonly apiRetryDelayMs = 2500;
 
   constructor(
     private configService: ConfigService,
@@ -29,15 +33,47 @@ export class GithubService {
     return this.orgName;
   }
 
+  private async performHttpRequest(
+    url: string,
+    retryCount = 0,
+  ): Promise<AxiosResponse> {
+    const response = await axios.get(url, { headers: this.headers });
+
+    // Handle GitHub's background calculation edge case (202 Accepted)
+    if (response.status === 202 && retryCount < this.maxApiRetries) {
+      const retryAfterHeader = response.headers['retry-after'];
+      const delayMs = retryAfterHeader
+        ? parseInt(retryAfterHeader, 10) * 1000
+        : this.apiRetryDelayMs;
+
+      this.logger.warn(
+        `GitHub returned 202 Accepted for ${url}. Waiting ${delayMs}ms for background processing... (Attempt ${retryCount + 1}/${this.maxApiRetries})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return this.performHttpRequest(url, retryCount + 1);
+    }
+
+    if (response.status === 202 && retryCount >= this.maxApiRetries) {
+      this.logger.error(
+        `GitHub 202 persisted after ${this.maxApiRetries} retries for ${url}`,
+      );
+      throw new HttpException(
+        'GitHub background computation is still processing. Please retry later.',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+
+    return response;
+  }
+
   private async fetchAllPages(url: string): Promise<any[]> {
     const results: any[] = [];
     let page = 1;
 
     while (true) {
       const separator = url.includes('?') ? '&' : '?';
-      const response = await axios.get(
+      const response = await this.performHttpRequest(
         `${url}${separator}per_page=100&page=${page}`,
-        { headers: this.headers },
       );
 
       const data = response.data;
@@ -58,9 +94,8 @@ export class GithubService {
 
     while (true) {
       const separator = url.includes('?') ? '&' : '?';
-      const response = await axios.get(
+      const response = await this.performHttpRequest(
         `${url}${separator}per_page=100&page=${page}`,
-        { headers: this.headers },
       );
 
       const items = response.data.items || [];
@@ -83,9 +118,8 @@ export class GithubService {
       const cached = this.cacheService.get<any[]>(cacheKey);
       if (cached) return cached;
 
-      const response = await axios.get(
+      const response = await this.performHttpRequest(
         `${this.baseUrl}/orgs/${this.orgName}/repos?per_page=${perPage}&page=${page}`,
-        { headers: this.headers },
       );
       const repos = response.data;
       this.cacheService.set(cacheKey, repos, CACHE_TTL);
@@ -176,9 +210,7 @@ export class GithubService {
         // Note: Search API results for PRs don't include merged_at at the top level usually
         if (pr.state === 'closed' && !pr.merged_at && pr.pull_request?.url) {
           try {
-            const response = await axios.get(pr.pull_request.url, {
-              headers: this.headers,
-            });
+            const response = await this.performHttpRequest(pr.pull_request.url);
             if (response.data.merged_at) {
               pr.merged_at = response.data.merged_at;
             }
@@ -212,9 +244,9 @@ export class GithubService {
     const cached = this.cacheService.get<any>(cacheKey);
     if (cached) return cached;
 
-    const response = await axios.get(`${this.baseUrl}/users/${username}`, {
-      headers: this.headers,
-    });
+    const response = await this.performHttpRequest(
+      `${this.baseUrl}/users/${username}`,
+    );
     this.cacheService.set(cacheKey, response.data);
     return response.data;
   }
@@ -256,12 +288,8 @@ export class GithubService {
 
     try {
       const [followersResponse, followingResponse] = await Promise.all([
-        axios.get(`${this.baseUrl}/users/${username}/followers`, {
-          headers: this.headers,
-        }),
-        axios.get(`${this.baseUrl}/users/${username}/following`, {
-          headers: this.headers,
-        }),
+        this.performHttpRequest(`${this.baseUrl}/users/${username}/followers`),
+        this.performHttpRequest(`${this.baseUrl}/users/${username}/following`),
       ]);
 
       const result = {

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -42,12 +42,17 @@ export class GithubService {
     // Handle GitHub's background calculation edge case (202 Accepted)
     if (response.status === 202 && retryCount < this.maxApiRetries) {
       const retryAfterHeader = response.headers['retry-after'];
-      const delayMs = retryAfterHeader
-        ? parseInt(retryAfterHeader, 10) * 1000
-        : this.apiRetryDelayMs;
+      let delayMs = this.apiRetryDelayMs;
+
+      if (retryAfterHeader) {
+        const parsed = parseInt(retryAfterHeader, 10);
+        if (!isNaN(parsed) && isFinite(parsed)) {
+          delayMs = parsed * 1000;
+        }
+      }
 
       this.logger.warn(
-        `GitHub returned 202 Accepted for ${url}. Waiting ${delayMs}ms for background processing... (Attempt ${retryCount + 1}/${this.maxApiRetries})`,
+        `GitHub returned 202 Accepted for ${url}. Waiting ${delayMs}ms for background processing... (Retry attempt ${retryCount + 1} of ${this.maxApiRetries})`,
       );
       await new Promise((resolve) => setTimeout(resolve, delayMs));
       return this.performHttpRequest(url, retryCount + 1);
@@ -214,8 +219,15 @@ export class GithubService {
             if (response.data.merged_at) {
               pr.merged_at = response.data.merged_at;
             }
-          } catch {
-            // Ignore errors for individual PR fetches to avoid failing the whole request
+          } catch (error) {
+            // Rethrow 503 Service Unavailable (persistent 202s) so the caller knows to try again later
+            if (
+              error instanceof HttpException &&
+              error.getStatus() === HttpStatus.SERVICE_UNAVAILABLE
+            ) {
+              throw error;
+            }
+            // Ignore other errors for individual PR fetches to avoid failing the whole request
           }
         }
         return pr;


### PR DESCRIPTION
## Description

This PR addresses the bug where GitHub API returns `202 Accepted` to indicate background processing, causing missing data inside the application. I have introduced a robust wrapper method `performHttpRequest` inside `GithubService` that detects the `202` status code and dynamically retries the request. It parses and respects GitHub's `Retry-After` header if present; otherwise, it defaults to a built-in delay (`maxApiRetries = 2`, `apiRetryDelayMs = 2500`). All `axios.get` calls containing authorization headers have been safely refactored to use this wrapper.

### Latest Updates (Refinements)

- **Robust `Retry-After` Parsing:** Modified the header parsing to safely fallback to the default delay if GitHub sends non-finite or HTTP date-based `Retry-After` values.
- **Improved Error Propagation:** Added an explicit error state (`throw new HttpException(..., HttpStatus.SERVICE_UNAVAILABLE)`) if the `202` persists beyond `maxApiRetries`. `searchUserPullRequests` now correctly bubbles up this 503 instead of swallowing it, preventing indefinite backend hanging and missing data caching.
- **Better Observability:** Clarified the log descriptions for API retry attempts to make debugging easier.

*(Note: This PR is fully up-to-date with `master` and focuses strictly on the 202 Accepted logic. It does not introduce any changes to API throttle limits or UI components, which were merged previously via other PRs).*

Fixes #594

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested locally by triggering background logic and verifying recursive retries.
- [x] Added comprehensive unit tests in the service spec files locking in the 202 retry behavior and error handling.
- [x] Validated against NestJS build and Eslint rules to ensure zero regressions in CI/CD.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
