### PR TITLE
fix(project): trim whitespace from search query before processing

### DIFF
--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -23,14 +23,14 @@ export class ProjectController {
   @Get('search')
   @Header('Cache-Control', 'public, max-age=300')
   async searchProjects(@Query('q') query: string) {
-    if (!query) {
+    if (!query || !query.trim()) {
       return {
         total: 0,
         repositories: [],
       };
     }
 
-    return this.projectService.searchProjects(query);
+    return this.projectService.searchProjects(query.trim());
   }
 }
 


### PR DESCRIPTION
## Problem
The `/api/projects/search` endpoint checks `if (!query)` to guard against
empty searches. However this check does not catch whitespace-only strings —
a query of `"   "` passes the check and gets forwarded to the GitHub search
API, causing unnecessary API usage and returning unexpected results.

## Fix
- Added `!query.trim()` to the guard condition
- Trimmed the query before passing it to the service so inputs like
  `" webiu "` are normalized to `"webiu"`

## Testing
- `q=""` → returns empty result (existing behaviour)
- `q="   "` → now returns empty result (fixed)
- `q=" webiu "` → now searches for `"webiu"` correctly
- All 72 existing tests pass
<img width="368" height="116" alt="image" src="https://github.com/user-attachments/assets/131b40ed-fc16-4801-b572-8c3be667855f" />

