### PR TITLE
fix(auth): add MinLength(6) validation to confirmPassword field

### DIFF
--- a/webiu-server/src/auth/dto/register.dto.ts
+++ b/webiu-server/src/auth/dto/register.dto.ts
@@ -22,6 +22,7 @@ export class RegisterDto {
 
   @IsNotEmpty()
   @IsString()
+  @MinLength(6)
   confirmPassword: string;
 
   @IsOptional()


### PR DESCRIPTION
## Problem

`RegisterDto` enforces `@MinLength(6)` on the `password` field but not on `confirmPassword`. This inconsistency means a registration request with a valid password and a single-character `confirmPassword` passes DTO validation silently.

**Example request that incorrectly passes validation:**

```json
{
  "name": "Test User",
  "email": "test@example.com",
  "password": "abc123",
  "confirmPassword": "x"
}
```

---

## Fix : #598 

Added `@MinLength(6)` to `confirmPassword` to match the existing constraint on `password`. The `MinLength` import was already present in the file.
<img width="571" height="100" alt="image" src="https://github.com/user-attachments/assets/5e846182-3abc-4d3b-8bcf-c122bb5f453f" />


---

## Testing

 Registration with `confirmPassword` shorter than 6 characters now returns a 400 Bad Request
All 72 existing backend tests pass

