### PR TITLE
Fix: load .env file for webiu-server in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     build:
       context: ./webiu-server
     container_name: webiu-server
-    env_files:
-      - ./webiu-server/ .env
+
+    env_file:
+      - ./webiu-server/.env
+
     ports:
       - 5050:5050
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,15 @@ services:
     build:
       context: ./webiu-server
     container_name: webiu-server
+    env_files:
+      - ./webiu-server/ .env
     ports:
       - 5050:5050
     environment:
       - NODE_ENV=development
     volumes:
       - ./webiu-server:/usr/src/app
-    command: ["npm", "start"]
+    command: [ "npm", "start" ]
 
   webiu-ui:
     build:


### PR DESCRIPTION
Description

This PR fixes the issue where the webiu-server service in docker-compose.yml does not load environment variables from a .env file.

Currently, only NODE_ENV=development is defined under the environment section. If additional environment variables (such as API keys, OAuth credentials, or secrets) are defined in a .env file, they are not injected into the container during runtime.

This PR adds the env_file directive to ensure environment variables from webiu-server/.env are loaded when the container starts.

Fixes #600


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Steps used to verify the fix:

Added a .env file inside the webiu-server directory.

Started the services using:

docker-compose up --build
Verified that environment variables defined in .env are available inside the webiu-server container.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
