### PR TITLE
Feat/make GitHub org configurable 

### DIFF
--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -48,3 +48,9 @@ CACHE_TTL_SECONDS=300
 # (Used for fetching repos, contributors, issues, PRs)
 # ==============================
 GITHUB_ACCESS_TOKEN=
+
+# ==============================
+# GitHub Organization Name
+# (Default: c2siorg)
+# ==============================
+GITHUB_ORG_NAME=c2siorg

--- a/webiu-server/src/github/github.service.spec.ts
+++ b/webiu-server/src/github/github.service.spec.ts
@@ -19,9 +19,10 @@ describe('GithubService', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn((key: string) => {
+            get: jest.fn((key: string, defaultValue?: any) => {
               if (key === 'GITHUB_ACCESS_TOKEN') return 'test-token';
-              return null;
+              if (key === 'GITHUB_ORG_NAME') return defaultValue || 'c2siorg';
+              return defaultValue || null;
             }),
           },
         },

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -10,13 +10,14 @@ export class GithubService {
   private readonly logger = new Logger(GithubService.name);
   private readonly baseUrl = 'https://api.github.com';
   private readonly accessToken: string;
-  private readonly orgName = 'c2siorg';
+  private orgName: string;
 
   constructor(
     private configService: ConfigService,
     private cacheService: CacheService,
   ) {
     this.accessToken = this.configService.get<string>('GITHUB_ACCESS_TOKEN');
+    this.orgName = this.configService.get<string>('GITHUB_ORG_NAME', 'c2siorg');
   }
 
   private get headers() {

--- a/webiu-ui/src/app/page/community/community.component.html
+++ b/webiu-ui/src/app/page/community/community.component.html
@@ -34,6 +34,14 @@
           @for (user of users; track $index) {
             <div class="card">
               <div class="card-data">
+                <img
+                  class="user-avatar"
+                  [src]="user.avatar_url || 'https://github.com/' + user.login + '.png'"
+                  [alt]="user.login + ' avatar'"
+                  loading="lazy"
+                  width="72"
+                  height="72"
+                />
                 <a
                   class="user-name"
                   href="https://github.com/{{ user.login }}"

--- a/webiu-ui/src/app/page/community/community.component.scss
+++ b/webiu-ui/src/app/page/community/community.component.scss
@@ -130,6 +130,21 @@
             justify-content: center;
             text-align: center;
 
+            .user-avatar {
+              width: 72px;
+              height: 72px;
+              border-radius: 50%;
+              object-fit: cover;
+              border: 1px solid var(--community-card-border, #e1e4e8);
+              margin-bottom: 10px;
+              background: var(--community-card-bg, #ffffff);
+
+              @media screen and (max-width: 480px) {
+                width: 64px;
+                height: 64px;
+              }
+            }
+
             .user-name {
               font-size: 16px;
               font-weight: 600;


### PR DESCRIPTION

closes #321 
Description
This PR makes the GitHub organization name configurable through an environment variable instead of being hardcoded, improving application flexibility and following 12-factor app principles.

Problem
The GitHub organization name c2siorg was hardcoded in the codebase, making it inflexible for users who want to use this project for different organizations without modifying and redeploying code.

Solution
Made [orgName] configurable via the GITHUB_ORG_NAME environment variable
Maintains backward compatibility with default value 'c2siorg'
No breaking changes to existing functionality
Files Changed
📝 Modified Files
[github.service.ts]

Changed [orgName] from readonly property to instance variable
Initialize in constructor: this.orgName = this.configService.get<string>('GITHUB_ORG_NAME', 'c2siorg')
[.env.example]

Added GITHUB_ORG_NAME=c2siorg configuration with documentation
[github.service.spec.ts]

Updated ConfigService mock to handle default values for GITHUB_ORG_NAME
Testing
 All tests passing (14/14)

