### PR TITLE
feat(graphql): add searchRepositories query and missing Repository fields

### DIFF
--- a/webiu-server/src/graphql/models/repository.model.ts
+++ b/webiu-server/src/graphql/models/repository.model.ts
@@ -6,6 +6,9 @@ export class Repository {
   name: string;
 
   @Field({ nullable: true })
+  full_name?: string;
+
+  @Field({ nullable: true })
   description?: string;
 
   @Field({ nullable: true })
@@ -21,5 +24,11 @@ export class Repository {
   forks_count: number;
 
   @Field(() => Int)
+  open_issues_count: number;
+
+  @Field(() => Int)
   pull_requests: number;
+
+  @Field(() => [String], { nullable: true })
+  topics?: string[];
 }

--- a/webiu-server/src/graphql/project.resolver.ts
+++ b/webiu-server/src/graphql/project.resolver.ts
@@ -14,4 +14,16 @@ export class ProjectResolver {
     const result = await this.projectService.getAllProjects(page, limit);
     return result?.repositories ?? [];
   }
+
+  @Query(() => [Repository])
+  async searchRepositories(
+    @Args('query', { type: () => String }) query: string,
+  ): Promise<Repository[]> {
+    if (!query || !query.trim()) return [];
+    const result = await this.projectService.searchProjects(query.trim());
+    return (
+      (result as { total: number; repositories: Repository[] })?.repositories ??
+      []
+    );
+  }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p></p><hr><h3>Closes #606 </h3><h2>Changes</h2><h3><strong>1. New <code inline="">searchRepositories</code> GraphQL query</strong></h3><p>Wires the existing <code inline="">searchProjects()</code> service method to GraphQL.<br>No new service logic, it just exposes what already exists via REST.</p><h3><strong>2. Missing fields added to <code inline="">Repository</code> model</strong></h3>


| Field | Type | Was it in REST? |
|---|---|---|
| `full_name` | String | yes |
| `open_issues_count` | Int | yes |
| `topics` | [String] | yes|

<h2>Example usage</h2><pre><code class="language-graphql">query {
  searchRepositories(query: "machine learning") {
    name
    full_name
    language
    stargazers_count
    open_issues_count
    topics
  }
}
</code></pre><h2>Testing</h2><ul><li><p>Build passes (<code inline="">npm run build</code>)</p></li><li><p>All 72 backend tests pass (<code inline="">npm test</code>)</p></li><li><p>Tested via GraphQL playground at <a href="http://localhost:5050/graphql">http://localhost:5050/graphql</a></p></li></ul><hr></body></html><!--EndFragment-->
</body>
</html>