### PR TITLE
fix(graphql): move contributor pagination logic to service layer

### DIFF
--- a/webiu-server/src/contributor/contributor.service.ts
+++ b/webiu-server/src/contributor/contributor.service.ts
@@ -86,6 +86,14 @@ export class ContributorService {
     }
   }
 
+  async getPaginatedContributors(page: number, limit: number) {
+    const all = (await this.getAllContributors()) as any[];
+    const total = all.length;
+    const start = (page - 1) * limit;
+    const contributors = all.slice(start, start + limit);
+    return { total, page, limit, contributors };
+  }
+
   async getUserCreatedIssues(username: string) {
     try {
       const issues = await this.githubService.searchUserIssues(username);

--- a/webiu-server/src/graphql/contributor.resolver.spec.ts
+++ b/webiu-server/src/graphql/contributor.resolver.spec.ts
@@ -6,8 +6,39 @@ import { GqlThrottlerGuard } from './gql-throttler.guard';
 describe('ContributorResolver', () => {
   let resolver: ContributorResolver;
 
+  const mockContributors = [
+    {
+      login: 'user1',
+      contributions: 50,
+      avatar_url: 'url1',
+      repos: ['repo1', 'repo2'],
+    },
+    {
+      login: 'user2',
+      contributions: 20,
+      avatar_url: 'url2',
+      repos: ['repo1'],
+    },
+    {
+      login: 'user3',
+      contributions: 10,
+      avatar_url: 'url3',
+      repos: ['repo3'],
+    },
+  ];
+
   const mockContributorService = {
     getAllContributors: jest.fn(),
+    getPaginatedContributors: jest.fn().mockImplementation((page, limit) => {
+      const start = (page - 1) * limit;
+      const contributors = mockContributors.slice(start, start + limit);
+      return Promise.resolve({
+        total: mockContributors.length,
+        page,
+        limit,
+        contributors,
+      });
+    }),
   };
 
   beforeEach(async () => {
@@ -33,66 +64,44 @@ describe('ContributorResolver', () => {
   });
 
   describe('contributors', () => {
-    const mockContributors = [
-      {
-        login: 'user1',
-        contributions: 50,
-        avatar_url: 'url1',
-        repos: ['repo1', 'repo2'],
-      },
-      {
-        login: 'user2',
-        contributions: 20,
-        avatar_url: 'url2',
-        repos: ['repo1'],
-      },
-      {
-        login: 'user3',
-        contributions: 10,
-        avatar_url: 'url3',
-        repos: ['repo3'],
-      },
-    ];
-
     it('should return paginated contributors from the service', async () => {
-      mockContributorService.getAllContributors.mockResolvedValue(
-        mockContributors,
-      );
-
       const result = await resolver.contributors(1, 30);
 
       expect(result).toEqual(mockContributors);
-      expect(mockContributorService.getAllContributors).toHaveBeenCalledTimes(
-        1,
-      );
+      expect(
+        mockContributorService.getPaginatedContributors,
+      ).toHaveBeenCalledWith(1, 30);
     });
 
-    it('should return empty array when no contributors exist', async () => {
-      mockContributorService.getAllContributors.mockResolvedValue([]);
+    it('should return empty array when page exceeds data', async () => {
+      mockContributorService.getPaginatedContributors.mockResolvedValueOnce({
+        total: 3,
+        page: 10,
+        limit: 30,
+        contributors: [],
+      });
 
-      const result = await resolver.contributors(1, 30);
+      const result = await resolver.contributors(10, 30);
 
       expect(result).toEqual([]);
     });
 
     it('should respect page and limit for pagination', async () => {
-      mockContributorService.getAllContributors.mockResolvedValue(
-        mockContributors,
-      );
-
       const result = await resolver.contributors(2, 2);
 
       expect(result).toEqual([mockContributors[2]]);
     });
 
-    it('should return empty array when page exceeds data', async () => {
-      mockContributorService.getAllContributors.mockResolvedValue(
-        mockContributors,
+    it('should throw BadRequestException when page is less than 1', async () => {
+      await expect(resolver.contributors(0, 30)).rejects.toThrow(
+        'page must be at least 1',
       );
+    });
 
-      const result = await resolver.contributors(10, 30);
-
-      expect(result).toEqual([]);
+    it('should throw BadRequestException when limit exceeds 100', async () => {
+      await expect(resolver.contributors(1, 101)).rejects.toThrow(
+        'limit must be between 1 and 100',
+      );
     });
   });
 });

--- a/webiu-server/src/graphql/contributor.resolver.ts
+++ b/webiu-server/src/graphql/contributor.resolver.ts
@@ -1,4 +1,5 @@
 import { Resolver, Query, Args, Int } from '@nestjs/graphql';
+import { BadRequestException } from '@nestjs/common';
 import { ContributorService } from '../contributor/contributor.service';
 import { Contributor } from './models/contributor.model';
 
@@ -11,9 +12,14 @@ export class ContributorResolver {
     @Args('page', { type: () => Int, defaultValue: 1 }) page: number,
     @Args('limit', { type: () => Int, defaultValue: 30 }) limit: number,
   ): Promise<Contributor[]> {
-    const all =
-      (await this.contributorService.getAllContributors()) as Contributor[];
-    const start = (page - 1) * limit;
-    return all.slice(start, start + limit);
+    if (page < 1) throw new BadRequestException('page must be at least 1');
+    if (limit < 1 || limit > 100)
+      throw new BadRequestException('limit must be between 1 and 100');
+
+    const result = await this.contributorService.getPaginatedContributors(
+      page,
+      limit,
+    );
+    return result.contributors as Contributor[];
   }
 }


### PR DESCRIPTION
## Changes
- Added `getPaginatedContributors(page, limit)` to `ContributorService`
- Resolver delegates to service instead of slicing in-place
- Added input validation: `page >= 1`, `limit` between 1 and 100
- Updated spec with validation tests
<img width="624" height="177" alt="image" src="https://github.com/user-attachments/assets/d4aa0972-977d-4014-bc91-c5db0206a59d" />
<img width="701" height="623" alt="image" src="https://github.com/user-attachments/assets/8d2a4c6b-4cc6-400e-bb3d-afca90dc7624" />


## Testing
- 73 tests pass (1 new test added)
- Build passes
<img width="359" height="97" alt="image" src="https://github.com/user-attachments/assets/e4bef982-6d80-4486-acf3-044230b3e64a" />
