### PR TITLE
fix(project): pass CACHE_TTL to getIssuesAndPr cache set call

### DIFF
--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -87,7 +87,7 @@ export class ProjectService {
       const pullRequests = data.filter((item) => item.pull_request).length;
 
       const result = { issues, pullRequests };
-      this.cacheService.set(cacheKey, result);
+      this.cacheService.set(cacheKey, result, CACHE_TTL);
       return result;
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
getIssuesAndPr was calling cacheService.set without a TTL, causing cached issue/PR counts to persist indefinitely. All other methods in ProjectService (getAllProjects, searchProjects) consistently pass CACHE_TTL=300. This aligns the behaviour across the service.
Fixes : #609 
