### PR TITLE
feat(analyzer): implement GitHub Repository Intelligence Analyzer with scoring, sync, CLI, tests, and docs (Issue #540)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vscode
 .idea
 *.log
+webiu-server/.analyzer/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - **Real-time Project Data** — Fetches repository stats (stars, forks, language, issues, PRs) directly from GitHub.
 - **Contributor Leaderboards** — Aggregates contributions across all repositories to rank contributors.
 - **Contributor Search** — Look up any contributor to see their issues and pull requests within the organization.
+- **Repository Intelligence Analyzer** — Analyze multiple GitHub repositories for activity, complexity, and learning difficulty.
 - **Dark Mode** — Toggle between light and dark themes with persistent preference.
 - **OAuth Sign-in** — Sign in with Google or GitHub accounts.
 - **Modern Stack** — Built with Angular 17+ (standalone components) and NestJS.
@@ -37,9 +38,10 @@
 6. [API Endpoints](#api-endpoints)
 7. [Linting & Code Quality](#linting--code-quality)
 8. [Testing](#testing)
-9. [Contributing](#contributing)
-10. [Documentation](#documentation)
-11. [License](#license)
+9. [Deployment (Fly.io)](#deployment-flyio)
+10. [Contributing](#contributing)
+11. [Documentation](#documentation)
+12. [License](#license)
 
 ## Features
 
@@ -198,10 +200,31 @@ For a deep dive into the architecture, module system, data flow, and caching str
 | `GET` | `/api/v1/auth/verify-email?token=...` | Verify email address |
 | `GET` | `/auth/google` | Google OAuth sign-in |
 | `GET` | `/auth/github` | GitHub OAuth sign-in |
+| `POST` | `/api/analyzer/analyze` | Analyze a list of GitHub repository URLs |
+| `POST` | `/api/analyzer/sync` | Trigger analyzer sync for stored repositories |
+| `GET` | `/api/analyzer/reports` | List stored analyzer reports |
+| `GET` | `/api/analyzer/reports/:owner/:repo` | Fetch latest report for one repository |
 
 Full API documentation (request/response schemas, validation, error codes) is in [`docs/API_DOCUMENTATION.md`](docs/API_DOCUMENTATION.md).
 
 A **Postman collection** for all endpoints is available at [`docs/webiu.postman_collection.json`](docs/webiu.postman_collection.json) — import it via **Postman → Import → File** to start testing immediately.
+
+### Analyzer CLI
+
+Run batch analysis directly from the backend package and write a structured report JSON file:
+
+```bash
+cd webiu-server
+npm run analyzer:run -- \
+  --repos https://github.com/nestjs/nest,https://github.com/angular/angular,https://github.com/vercel/next.js,https://github.com/facebook/react,https://github.com/microsoft/TypeScript \
+  --output ../docs/examples/analyzer-sample-report.json
+```
+
+Environment variables for analyzer behavior are documented in [`webiu-server/.env.example`](webiu-server/.env.example):
+
+- `ANALYZER_SYNC_ENABLED`
+- `ANALYZER_SYNC_INTERVAL_MINUTES`
+- `ANALYZER_STORE_PATH`
 
 ## Linting & Code Quality
 
@@ -228,6 +251,46 @@ cd webiu-server && npm test
 # Frontend (Karma + Jasmine)
 cd webiu-ui && ng test
 ```
+
+## Deployment (Fly.io)
+
+Backend deployment is prepared via [`webiu-server/fly.toml`](webiu-server/fly.toml).
+
+### Prerequisites
+
+- Install Fly CLI: `brew install flyctl`
+- Login: `fly auth login`
+
+### Deploy Backend
+
+```bash
+cd webiu-server
+fly launch --no-deploy
+fly secrets set \
+  JWT_SECRET=your_jwt_secret \
+  GITHUB_ACCESS_TOKEN=your_github_token \
+  FRONTEND_BASE_URL=https://your-frontend-url
+fly deploy
+```
+
+### Verify
+
+```bash
+fly status
+fly logs
+```
+
+After deployment, test analyzer endpoint:
+
+```bash
+curl -X POST https://<your-fly-app>.fly.dev/api/analyzer/analyze \
+  -H "content-type: application/json" \
+  -d '{"repositories":["https://github.com/nestjs/nest"]}'
+```
+
+Deployment URL for PR submission:
+
+- Backend URL: `https://<your-fly-app>.fly.dev`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ cd webiu-server && npm test
 cd webiu-ui && ng test
 ```
 
-## Deployment (Fly.io)
+## Deployment (Fly.io / Railway)
 
 Backend deployment is prepared via [`webiu-server/fly.toml`](webiu-server/fly.toml).
 
@@ -291,6 +291,37 @@ curl -X POST https://<your-fly-app>.fly.dev/api/analyzer/analyze \
 Deployment URL for PR submission:
 
 - Backend URL: `https://<your-fly-app>.fly.dev`
+
+### Deploy on Railway (fallback)
+
+If Fly.io account billing is not ready, you can deploy the same backend on Railway.
+
+```bash
+cd webiu-server
+railway login
+railway init
+railway up
+```
+
+Set environment variables in Railway dashboard for the service:
+
+- `PORT=5050`
+- `NODE_ENV=production`
+- `JWT_SECRET=your_jwt_secret`
+- `GITHUB_ACCESS_TOKEN=your_github_token`
+- `FRONTEND_BASE_URL=https://your-frontend-url`
+
+After deployment, verify analyzer endpoint:
+
+```bash
+curl -X POST https://<your-railway-domain>/api/analyzer/analyze \
+  -H "content-type: application/json" \
+  -d '{"repositories":["https://github.com/nestjs/nest"]}'
+```
+
+Deployment URL for PR submission:
+
+- Railway URL: `https://<your-railway-domain>`
 
 ## Contributing
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -624,7 +624,178 @@ GET http://localhost:5050/api/user/followersAndFollowing/octocat
 
 ---
 
-## 6. Error Reference
+## 6. Analyzer
+
+### `POST /api/analyzer/analyze`
+
+Accepts a list of GitHub repository URLs and returns an intelligence report per repository.
+
+**Request**
+
+```
+POST http://localhost:5050/api/analyzer/analyze
+Content-Type: application/json
+```
+
+**Request Body**
+
+```json
+{
+  "repositories": [
+    "https://github.com/nestjs/nest",
+    "https://github.com/angular/angular"
+  ],
+  "forceRefresh": true
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `repositories` | `string[]` | ✅ Yes | GitHub repository URLs |
+| `forceRefresh` | `boolean` | ❌ No | Ignore in-memory cache if `true` |
+
+**Success Response — `201 Created`**
+
+```json
+{
+  "reports": [
+    {
+      "owner": "nestjs",
+      "repo": "nest",
+      "fullName": "nestjs/nest",
+      "url": "https://github.com/nestjs/nest",
+      "generatedAt": "2026-03-29T12:10:50.262Z",
+      "status": "partial",
+      "metrics": {
+        "activityScore": 94,
+        "complexityScore": 77,
+        "learningDifficulty": "Advanced"
+      },
+      "breakdown": {
+        "stars": 74996,
+        "forks": 8266,
+        "contributors": 658,
+        "recentCommits30d": 239,
+        "recentIssues30d": 12,
+        "recentPrs30d": 179,
+        "languages": ["TypeScript", "JavaScript", "Shell"],
+        "fileCount": 2108,
+        "dependencyFiles": ["package.json", "package-lock.json"]
+      },
+      "limitations": [
+        "No GITHUB_ACCESS_TOKEN configured. Unauthenticated requests have lower rate limits."
+      ]
+    }
+  ],
+  "syncRun": {
+    "id": "1774786247051-j7pzd216",
+    "startedAt": "2026-03-29T12:10:47.051Z",
+    "endedAt": "2026-03-29T12:10:52.789Z",
+    "status": "partial",
+    "repositoriesTotal": 2,
+    "repositoriesSucceeded": 1,
+    "repositoriesFailed": 1,
+    "errors": []
+  }
+}
+```
+
+### `POST /api/analyzer/sync`
+
+Triggers a refresh. If `repositories` is provided, that list is analyzed immediately. Otherwise, all previously stored repositories are re-analyzed.
+
+**Request**
+
+```
+POST http://localhost:5050/api/analyzer/sync
+Content-Type: application/json
+```
+
+**Request Body (optional)**
+
+```json
+{
+  "repositories": [
+    "https://github.com/facebook/react"
+  ]
+}
+```
+
+### `GET /api/analyzer/reports`
+
+Returns paginated stored analyzer reports.
+
+**Request**
+
+```
+GET http://localhost:5050/api/analyzer/reports?page=1&limit=20
+```
+
+### `GET /api/analyzer/reports/:owner/:repo`
+
+Returns the latest stored analyzer report for a single repository.
+
+**Request**
+
+```
+GET http://localhost:5050/api/analyzer/reports/nestjs/nest
+```
+
+### `GET /api/analyzer/sync-history`
+
+Returns recent sync runs and partial-failure details.
+
+**Request**
+
+```
+GET http://localhost:5050/api/analyzer/sync-history?limit=20
+```
+
+### Scoring Formula
+
+`activityScore` (0-100) combines recent commits, contributors, issues, and pull requests:
+
+```
+activityScore = round(
+  min(35, recentCommits30d * 0.9) +
+  min(20, contributors * 2.2) +
+  min(20, recentIssues30d * 1.2) +
+  min(25, recentPrs30d * 1.4)
+)
+```
+
+`complexityScore` (0-100) combines repository breadth and dependency surface:
+
+```
+complexityScore = round(
+  min(40, log10(fileCount + 1) * 14) +
+  min(25, languageCount * 5) +
+  min(25, dependencyFileCount * 6) +
+  min(10, log10(stars + 1) * 4)
+)
+```
+
+Difficulty classification uses weighted score:
+
+```
+weighted = activityScore * 0.45 + complexityScore * 0.55
+```
+
+| Weighted Score | Difficulty |
+|---------------|------------|
+| `< 35` | `Beginner` |
+| `>= 35` and `< 65` | `Intermediate` |
+| `>= 65` | `Advanced` |
+
+### Notes
+
+- The analyzer stores reports in a JSON-backed persistence file configured by `ANALYZER_STORE_PATH`.
+- When GitHub rate limits are reached, reports are still returned with `status: "failed"` and explicit error messages.
+- Without `GITHUB_ACCESS_TOKEN`, GitHub applies stricter limits and sample runs may produce partial results.
+
+---
+
+## 7. Error Reference
 
 All error responses follow NestJS's default exception format:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,8 @@ This document explains how WebiU 2.0 is built, how the pieces fit together, and 
 
 WebiU 2.0 is a full-stack application that showcases C2SI/SCoRe Lab's open-source projects and contributors. It pulls data from the GitHub API, processes and caches it on the backend, and presents it through a responsive Angular frontend.
 
+The backend now also includes a **Repository Intelligence Analyzer** that scores repositories by activity and complexity, classifies learning difficulty, and persists generated reports for scheduled refreshes.
+
 ```
 ┌──────────────────┐         REST API         ┌──────────────────┐
 │                  │  ──────────────────────►  │                  │
@@ -112,6 +114,7 @@ AppModule (root)
 ├── AuthModule            — JWT auth, Google/GitHub OAuth
 ├── ProjectModule         — Project listing and issue/PR counts
 ├── ContributorModule     — Contributor leaderboards and per-user stats
+├── AnalyzerModule        — Repository intelligence scoring + sync
 └── UserModule            — User management
 ```
 
@@ -187,6 +190,24 @@ A **Postman collection** with all endpoints pre-configured is available at **[`w
 | `GET` | `/auth/github` | Initiate GitHub OAuth |
 | `GET` | `/auth/github/callback` | GitHub OAuth callback |
 | `GET` | `/api/user/followersAndFollowing/:username` | User followers/following (stub) |
+
+### Repository Intelligence Analyzer
+
+The analyzer is implemented in `webiu-server/src/analyzer` and has five responsibilities:
+
+1. Parse and validate GitHub repository URLs from API/CLI input.
+2. Ingest repository metadata from GitHub (stars, forks, contributors, commits, issues/PRs, languages, tree files).
+3. Compute activity and complexity scores, then classify difficulty (`Beginner`, `Intermediate`, `Advanced`).
+4. Persist reports and sync history to a JSON store (path configurable via `ANALYZER_STORE_PATH`).
+5. Run scheduled refreshes at fixed intervals (`ANALYZER_SYNC_INTERVAL_MINUTES`) with manual sync triggers available via API.
+
+Analyzer API endpoints:
+
+- `POST /api/analyzer/analyze`
+- `POST /api/analyzer/sync`
+- `GET /api/analyzer/reports`
+- `GET /api/analyzer/reports/:owner/:repo`
+- `GET /api/analyzer/sync-history`
 
 ---
 

--- a/docs/examples/analyzer-sample-report.json
+++ b/docs/examples/analyzer-sample-report.json
@@ -1,0 +1,177 @@
+{
+  "reports": [
+    {
+      "owner": "nestjs",
+      "repo": "nest",
+      "fullName": "nestjs/nest",
+      "url": "https://github.com/nestjs/nest",
+      "generatedAt": "2026-03-29T12:10:50.262Z",
+      "status": "partial",
+      "metrics": {
+        "activityScore": 94,
+        "complexityScore": 77,
+        "learningDifficulty": "Advanced"
+      },
+      "breakdown": {
+        "stars": 74996,
+        "forks": 8266,
+        "contributors": 658,
+        "recentCommits30d": 239,
+        "recentIssues30d": 12,
+        "recentPrs30d": 179,
+        "languages": [
+          "TypeScript",
+          "JavaScript",
+          "Shell"
+        ],
+        "fileCount": 2108,
+        "dependencyFiles": [
+          "package.json",
+          "package-lock.json"
+        ]
+      },
+      "limitations": [
+        "No GITHUB_ACCESS_TOKEN configured. Unauthenticated requests have lower rate limits."
+      ]
+    },
+    {
+      "owner": "angular",
+      "repo": "angular",
+      "fullName": "angular/angular",
+      "url": "https://github.com/angular/angular",
+      "generatedAt": "2026-03-29T12:10:52.488Z",
+      "status": "failed",
+      "metrics": {
+        "activityScore": 0,
+        "complexityScore": 0,
+        "learningDifficulty": "Beginner"
+      },
+      "breakdown": {
+        "stars": 0,
+        "forks": 0,
+        "contributors": 0,
+        "recentCommits30d": 0,
+        "recentIssues30d": 0,
+        "recentPrs30d": 0,
+        "languages": [],
+        "fileCount": 0,
+        "dependencyFiles": []
+      },
+      "limitations": [
+        "Repository data could not be retrieved."
+      ],
+      "errorMessage": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+    },
+    {
+      "owner": "vercel",
+      "repo": "next.js",
+      "fullName": "vercel/next.js",
+      "url": "https://github.com/vercel/next.js",
+      "generatedAt": "2026-03-29T12:10:52.587Z",
+      "status": "failed",
+      "metrics": {
+        "activityScore": 0,
+        "complexityScore": 0,
+        "learningDifficulty": "Beginner"
+      },
+      "breakdown": {
+        "stars": 0,
+        "forks": 0,
+        "contributors": 0,
+        "recentCommits30d": 0,
+        "recentIssues30d": 0,
+        "recentPrs30d": 0,
+        "languages": [],
+        "fileCount": 0,
+        "dependencyFiles": []
+      },
+      "limitations": [
+        "Repository data could not be retrieved."
+      ],
+      "errorMessage": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+    },
+    {
+      "owner": "facebook",
+      "repo": "react",
+      "fullName": "facebook/react",
+      "url": "https://github.com/facebook/react",
+      "generatedAt": "2026-03-29T12:10:52.694Z",
+      "status": "failed",
+      "metrics": {
+        "activityScore": 0,
+        "complexityScore": 0,
+        "learningDifficulty": "Beginner"
+      },
+      "breakdown": {
+        "stars": 0,
+        "forks": 0,
+        "contributors": 0,
+        "recentCommits30d": 0,
+        "recentIssues30d": 0,
+        "recentPrs30d": 0,
+        "languages": [],
+        "fileCount": 0,
+        "dependencyFiles": []
+      },
+      "limitations": [
+        "Repository data could not be retrieved."
+      ],
+      "errorMessage": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+    },
+    {
+      "owner": "microsoft",
+      "repo": "TypeScript",
+      "fullName": "microsoft/TypeScript",
+      "url": "https://github.com/microsoft/TypeScript",
+      "generatedAt": "2026-03-29T12:10:52.789Z",
+      "status": "failed",
+      "metrics": {
+        "activityScore": 0,
+        "complexityScore": 0,
+        "learningDifficulty": "Beginner"
+      },
+      "breakdown": {
+        "stars": 0,
+        "forks": 0,
+        "contributors": 0,
+        "recentCommits30d": 0,
+        "recentIssues30d": 0,
+        "recentPrs30d": 0,
+        "languages": [],
+        "fileCount": 0,
+        "dependencyFiles": []
+      },
+      "limitations": [
+        "Repository data could not be retrieved."
+      ],
+      "errorMessage": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+    }
+  ],
+  "syncRun": {
+    "id": "1774786247051-j7pzd216",
+    "startedAt": "2026-03-29T12:10:47.051Z",
+    "status": "partial",
+    "repositoriesTotal": 5,
+    "repositoriesSucceeded": 1,
+    "repositoriesFailed": 4,
+    "errors": [
+      {
+        "repository": "angular/angular",
+        "message": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+      },
+      {
+        "repository": "vercel/next.js",
+        "message": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+      },
+      {
+        "repository": "facebook/react",
+        "message": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+      },
+      {
+        "repository": "microsoft/TypeScript",
+        "message": "GitHub rate limit exhausted. Reset at 2026-03-29T12:38:53.000Z"
+      }
+    ],
+    "endedAt": "2026-03-29T12:10:52.789Z"
+  }
+}

--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -48,3 +48,10 @@ CACHE_TTL_SECONDS=300
 # (Used for fetching repos, contributors, issues, PRs)
 # ==============================
 GITHUB_ACCESS_TOKEN=
+
+# ==============================
+# Analyzer Configuration
+# ==============================
+ANALYZER_SYNC_ENABLED=true
+ANALYZER_SYNC_INTERVAL_MINUTES=60
+ANALYZER_STORE_PATH=.analyzer/reports.json

--- a/webiu-server/fly.toml
+++ b/webiu-server/fly.toml
@@ -1,0 +1,21 @@
+app = "webiu-analyzer"
+primary_region = "sin"
+
+[build]
+
+[env]
+  PORT = "5050"
+  NODE_ENV = "production"
+
+[http_service]
+  internal_port = 5050
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/webiu-server/package.json
+++ b/webiu-server/package.json
@@ -10,6 +10,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "analyzer:run": "ts-node -r tsconfig-paths/register src/analyzer/cli.ts",
     "lint": "eslint \"{src,apps,libs}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/webiu-server/src/analyzer/analyzer.controller.spec.ts
+++ b/webiu-server/src/analyzer/analyzer.controller.spec.ts
@@ -1,0 +1,140 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyzerController } from './analyzer.controller';
+import { AnalyzerService } from './analyzer.service';
+
+describe('AnalyzerController', () => {
+  let controller: AnalyzerController;
+
+  const mockAnalyzerService = {
+    analyzeRepositories: jest.fn(),
+    syncStoredRepositories: jest.fn(),
+    getStoredReports: jest.fn(),
+    getStoredReport: jest.fn(),
+    getSyncHistory: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyzerController],
+      providers: [{ provide: AnalyzerService, useValue: mockAnalyzerService }],
+    }).compile();
+
+    controller = module.get<AnalyzerController>(AnalyzerController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('analyze', () => {
+    it('should pass repositories and options to service', async () => {
+      const payload = {
+        repositories: ['https://github.com/nestjs/nest'],
+        forceRefresh: true,
+      };
+      const mockResult = { reports: [], syncRun: { id: 'run-1' } };
+      mockAnalyzerService.analyzeRepositories.mockResolvedValue(mockResult);
+
+      const result = await controller.analyze(payload);
+
+      expect(result).toEqual(mockResult);
+      expect(mockAnalyzerService.analyzeRepositories).toHaveBeenCalledWith(
+        payload.repositories,
+        {
+          forceRefresh: true,
+          persist: true,
+        },
+      );
+    });
+  });
+
+  describe('syncNow', () => {
+    it('should sync provided repositories when present in payload', async () => {
+      const payload = {
+        repositories: ['https://github.com/facebook/react'],
+      };
+      const mockResult = { reports: [{ fullName: 'facebook/react' }] };
+      mockAnalyzerService.analyzeRepositories.mockResolvedValue(mockResult);
+
+      const result = await controller.syncNow(payload);
+
+      expect(result).toEqual(mockResult);
+      expect(mockAnalyzerService.analyzeRepositories).toHaveBeenCalledWith(
+        payload.repositories,
+        {
+          forceRefresh: true,
+          persist: true,
+        },
+      );
+      expect(mockAnalyzerService.syncStoredRepositories).not.toHaveBeenCalled();
+    });
+
+    it('should sync stored repositories when payload has no repositories', async () => {
+      const mockResult = { reports: [] };
+      mockAnalyzerService.syncStoredRepositories.mockResolvedValue(mockResult);
+
+      const result = await controller.syncNow({});
+
+      expect(result).toEqual(mockResult);
+      expect(mockAnalyzerService.syncStoredRepositories).toHaveBeenCalled();
+      expect(mockAnalyzerService.analyzeRepositories).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getReports', () => {
+    it('should return paginated reports from service', () => {
+      const mockResult = {
+        total: 1,
+        page: 2,
+        limit: 10,
+        reports: [{ fullName: 'nestjs/nest' }],
+      };
+      mockAnalyzerService.getStoredReports.mockReturnValue(mockResult);
+
+      const result = controller.getReports({ page: 2, limit: 10 });
+
+      expect(result).toEqual(mockResult);
+      expect(mockAnalyzerService.getStoredReports).toHaveBeenCalledWith(2, 10);
+    });
+  });
+
+  describe('getReport', () => {
+    it('should return report when found', () => {
+      const report = { owner: 'nestjs', repo: 'nest', fullName: 'nestjs/nest' };
+      mockAnalyzerService.getStoredReport.mockReturnValue(report);
+
+      const result = controller.getReport('nestjs', 'nest');
+
+      expect(result).toEqual(report);
+      expect(mockAnalyzerService.getStoredReport).toHaveBeenCalledWith(
+        'nestjs',
+        'nest',
+      );
+    });
+
+    it('should throw NotFoundException when report does not exist', () => {
+      mockAnalyzerService.getStoredReport.mockReturnValue(null);
+
+      expect(() => controller.getReport('missing', 'repo')).toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getSyncHistory', () => {
+    it('should apply numeric bounds and call service', () => {
+      const history = [{ id: 'run-1' }];
+      mockAnalyzerService.getSyncHistory.mockReturnValue(history);
+
+      const result = controller.getSyncHistory('999');
+
+      expect(result).toEqual(history);
+      expect(mockAnalyzerService.getSyncHistory).toHaveBeenCalledWith(100);
+    });
+  });
+});

--- a/webiu-server/src/analyzer/analyzer.controller.ts
+++ b/webiu-server/src/analyzer/analyzer.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Header,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { AnalyzeRequestDto } from './dto/analyze-request.dto';
+import { ReportQueryDto } from './dto/report-query.dto';
+import { AnalyzerService } from './analyzer.service';
+
+@Controller('api/analyzer')
+export class AnalyzerController {
+  constructor(private readonly analyzerService: AnalyzerService) {}
+
+  @Post('analyze')
+  async analyze(@Body() body: AnalyzeRequestDto) {
+    return this.analyzerService.analyzeRepositories(body.repositories, {
+      forceRefresh: body.forceRefresh,
+      persist: true,
+    });
+  }
+
+  @Post('sync')
+  async syncNow(@Body() body: Partial<AnalyzeRequestDto>) {
+    if (body?.repositories?.length) {
+      return this.analyzerService.analyzeRepositories(body.repositories, {
+        forceRefresh: true,
+        persist: true,
+      });
+    }
+    return this.analyzerService.syncStoredRepositories();
+  }
+
+  @Get('reports')
+  @Header('Cache-Control', 'public, max-age=60')
+  getReports(@Query() query: ReportQueryDto) {
+    return this.analyzerService.getStoredReports(query.page, query.limit);
+  }
+
+  @Get('reports/:owner/:repo')
+  @Header('Cache-Control', 'public, max-age=60')
+  getReport(@Param('owner') owner: string, @Param('repo') repo: string) {
+    const report = this.analyzerService.getStoredReport(owner, repo);
+    if (!report) {
+      throw new NotFoundException(`No report found for ${owner}/${repo}`);
+    }
+    return report;
+  }
+
+  @Get('sync-history')
+  getSyncHistory(@Query('limit') limit = '20') {
+    const numericLimit = Math.max(1, Math.min(100, parseInt(limit, 10) || 20));
+    return this.analyzerService.getSyncHistory(numericLimit);
+  }
+}

--- a/webiu-server/src/analyzer/analyzer.module.ts
+++ b/webiu-server/src/analyzer/analyzer.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { AnalyzerController } from './analyzer.controller';
+import { AnalyzerService } from './analyzer.service';
+import { AnalyzerStoreService } from './analyzer.store.service';
+
+@Module({
+  imports: [CommonModule],
+  controllers: [AnalyzerController],
+  providers: [AnalyzerService, AnalyzerStoreService],
+  exports: [AnalyzerService],
+})
+export class AnalyzerModule {}

--- a/webiu-server/src/analyzer/analyzer.service.spec.ts
+++ b/webiu-server/src/analyzer/analyzer.service.spec.ts
@@ -1,0 +1,108 @@
+import { BadRequestException } from '@nestjs/common';
+import { AnalyzerService } from './analyzer.service';
+import { AnalyzerBreakdown } from './types';
+
+describe('AnalyzerService', () => {
+  let service: AnalyzerService;
+
+  const mockConfigService = {
+    get: jest.fn((key: string, fallback?: string) => {
+      if (key === 'ANALYZER_SYNC_ENABLED') return 'false';
+      if (key === 'GITHUB_ACCESS_TOKEN') return undefined;
+      return fallback;
+    }),
+  };
+
+  const mockCacheService = {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+
+  const mockStoreService = {
+    createSyncRun: jest.fn(),
+    updateSyncRun: jest.fn(),
+    saveReport: jest.fn(),
+    setRepoCursor: jest.fn(),
+    getReports: jest.fn().mockReturnValue([]),
+    getReport: jest.fn(),
+    getSyncHistory: jest.fn().mockReturnValue([]),
+    getRepoCursor: jest.fn(),
+  };
+
+  beforeEach(() => {
+    service = new AnalyzerService(
+      mockConfigService as any,
+      mockCacheService as any,
+      mockStoreService as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should classify low weighted score as Beginner', () => {
+    const level = (service as any).classifyDifficulty(10, 20);
+    expect(level).toBe('Beginner');
+  });
+
+  it('should classify medium weighted score as Intermediate', () => {
+    const level = (service as any).classifyDifficulty(60, 50);
+    expect(level).toBe('Intermediate');
+  });
+
+  it('should classify high weighted score as Advanced', () => {
+    const level = (service as any).classifyDifficulty(90, 90);
+    expect(level).toBe('Advanced');
+  });
+
+  it('should compute activity score within expected range', () => {
+    const breakdown: AnalyzerBreakdown = {
+      stars: 1000,
+      forks: 100,
+      contributors: 9,
+      recentCommits30d: 30,
+      recentIssues30d: 8,
+      recentPrs30d: 9,
+      languages: ['TypeScript', 'JavaScript'],
+      fileCount: 200,
+      dependencyFiles: ['package.json'],
+    };
+
+    const score = (service as any).computeActivityScore(breakdown);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('should compute complexity score within expected range', () => {
+    const breakdown: AnalyzerBreakdown = {
+      stars: 15000,
+      forks: 2000,
+      contributors: 100,
+      recentCommits30d: 100,
+      recentIssues30d: 20,
+      recentPrs30d: 40,
+      languages: ['TypeScript', 'JavaScript', 'Shell', 'Python'],
+      fileCount: 5000,
+      dependencyFiles: ['package.json', 'package-lock.json', 'Dockerfile'],
+    };
+
+    const score = (service as any).computeComplexityScore(breakdown);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('should parse valid GitHub repository URL', () => {
+    const parsed = (service as any).parseRepositoryUrl(
+      'https://github.com/nestjs/nest',
+    );
+    expect(parsed.fullName).toBe('nestjs/nest');
+    expect(parsed.url).toBe('https://github.com/nestjs/nest');
+  });
+
+  it('should reject invalid repository URL', () => {
+    expect(() =>
+      (service as any).parseRepositoryUrl('https://example.com/not-github'),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/webiu-server/src/analyzer/analyzer.service.ts
+++ b/webiu-server/src/analyzer/analyzer.service.ts
@@ -1,0 +1,540 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios, { AxiosRequestConfig } from 'axios';
+import { CacheService } from '../common/cache.service';
+import { AnalyzerStoreService } from './analyzer.store.service';
+import {
+  AnalyzerBreakdown,
+  AnalyzerInputRepository,
+  AnalyzerMetrics,
+  AnalyzerReport,
+  AnalyzerSyncRun,
+  DifficultyLevel,
+} from './types';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+const ANALYZER_CACHE_TTL_SECONDS = 600;
+const DEFAULT_SYNC_INTERVAL_MINUTES = 60;
+const MAX_REPOS_PER_REQUEST = 100;
+const RECENT_WINDOW_DAYS = 30;
+
+@Injectable()
+export class AnalyzerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AnalyzerService.name);
+  private readonly githubToken: string;
+  private syncTimer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly cacheService: CacheService,
+    private readonly storeService: AnalyzerStoreService,
+  ) {
+    this.githubToken = this.configService.get<string>('GITHUB_ACCESS_TOKEN');
+  }
+
+  onModuleInit(): void {
+    const enabled =
+      this.configService.get<string>('ANALYZER_SYNC_ENABLED', 'true') === 'true';
+    if (!enabled) {
+      return;
+    }
+
+    const rawInterval = this.configService.get<string>(
+      'ANALYZER_SYNC_INTERVAL_MINUTES',
+      String(DEFAULT_SYNC_INTERVAL_MINUTES),
+    );
+    const interval = Math.max(
+      1,
+      parseInt(rawInterval || String(DEFAULT_SYNC_INTERVAL_MINUTES), 10) ||
+        DEFAULT_SYNC_INTERVAL_MINUTES,
+    );
+
+    this.syncTimer = setInterval(() => {
+      this.syncStoredRepositories().catch((error) => {
+        this.logger.warn(`Scheduled analyzer sync failed: ${error.message}`);
+      });
+    }, interval * 60_000);
+
+    this.logger.log(`Analyzer scheduler started with ${interval} minute interval`);
+  }
+
+  onModuleDestroy(): void {
+    if (this.syncTimer) {
+      clearInterval(this.syncTimer);
+    }
+  }
+
+  async analyzeRepositories(
+    repositoryUrls: string[],
+    options?: { forceRefresh?: boolean; persist?: boolean },
+  ): Promise<{ reports: AnalyzerReport[]; syncRun?: AnalyzerSyncRun }> {
+    if (!Array.isArray(repositoryUrls) || repositoryUrls.length === 0) {
+      throw new BadRequestException('At least one repository URL is required');
+    }
+    if (repositoryUrls.length > MAX_REPOS_PER_REQUEST) {
+      throw new BadRequestException(
+        `Maximum ${MAX_REPOS_PER_REQUEST} repositories are allowed per request`,
+      );
+    }
+
+    const repositories = repositoryUrls.map((url) => this.parseRepositoryUrl(url));
+    const uniqueByFullName = new Map<string, AnalyzerInputRepository>();
+    for (const repo of repositories) {
+      uniqueByFullName.set(repo.fullName, repo);
+    }
+
+    const uniqueRepositories = [...uniqueByFullName.values()];
+    const syncRun = this.storeService.createSyncRun(uniqueRepositories.length);
+    const reports: AnalyzerReport[] = [];
+
+    for (const repository of uniqueRepositories) {
+      try {
+        const report = await this.analyzeSingleRepository(repository, options);
+        reports.push(report);
+        syncRun.repositoriesSucceeded += 1;
+
+        if (options?.persist !== false) {
+          this.storeService.saveReport(report);
+          this.storeService.setRepoCursor(repository.fullName, report.generatedAt);
+        }
+      } catch (error) {
+        syncRun.repositoriesFailed += 1;
+        const message = error?.message || 'Unknown error';
+        syncRun.errors.push({ repository: repository.fullName, message });
+
+        reports.push(this.createFailedReport(repository, message));
+      }
+    }
+
+    syncRun.endedAt = new Date().toISOString();
+    syncRun.status =
+      syncRun.repositoriesFailed === 0
+        ? 'completed'
+        : syncRun.repositoriesSucceeded > 0
+          ? 'partial'
+          : 'failed';
+
+    this.storeService.updateSyncRun(syncRun);
+
+    return { reports, syncRun };
+  }
+
+  getStoredReports(page = 1, limit = 20): {
+    total: number;
+    page: number;
+    limit: number;
+    reports: AnalyzerReport[];
+  } {
+    const normalizedPage = Math.max(1, page || 1);
+    const normalizedLimit = Math.min(100, Math.max(1, limit || 20));
+    const allReports = this.storeService.getReports();
+
+    const start = (normalizedPage - 1) * normalizedLimit;
+    const reports = allReports.slice(start, start + normalizedLimit);
+
+    return {
+      total: allReports.length,
+      page: normalizedPage,
+      limit: normalizedLimit,
+      reports,
+    };
+  }
+
+  getStoredReport(owner: string, repo: string): AnalyzerReport | null {
+    return this.storeService.getReport(owner, repo) || null;
+  }
+
+  getSyncHistory(limit = 20): AnalyzerSyncRun[] {
+    return this.storeService.getSyncHistory(limit);
+  }
+
+  async syncStoredRepositories(): Promise<{ reports: AnalyzerReport[] }> {
+    const stored = this.storeService.getReports();
+    const urls = stored.map((report) => report.url);
+
+    if (urls.length === 0) {
+      return { reports: [] };
+    }
+
+    const { reports } = await this.analyzeRepositories(urls, {
+      forceRefresh: true,
+      persist: true,
+    });
+    return { reports };
+  }
+
+  private async analyzeSingleRepository(
+    repository: AnalyzerInputRepository,
+    options?: { forceRefresh?: boolean; persist?: boolean },
+  ): Promise<AnalyzerReport> {
+    const cacheKey = `analyzer_report_${repository.fullName}`;
+    const canUseCache = !options?.forceRefresh;
+    const cached = this.cacheService.get<AnalyzerReport>(cacheKey);
+
+    if (canUseCache && cached) {
+      return cached;
+    }
+
+    const repoDetails = await this.githubRequest<any>(
+      `/repos/${repository.owner}/${repository.repo}`,
+    );
+
+    const sinceIso = this.getIncrementalSinceISO(repository.fullName);
+    const sinceDate = sinceIso.slice(0, 10);
+    const [contributors, languages, fileTree, recentCommits, recentIssues, recentPrs] =
+      await Promise.all([
+        this.getContributorCount(repository.owner, repository.repo),
+        this.safe(() =>
+          this.githubRequest<Record<string, number>>(
+            `/repos/${repository.owner}/${repository.repo}/languages`,
+          ),
+        ).then((value) => value || {}),
+        this.getRepositoryTree(
+          repository.owner,
+          repository.repo,
+          repoDetails.default_branch,
+        ),
+        this.getRecentCommitCount(repository.owner, repository.repo, sinceIso),
+        this.getRecentSearchCount(
+          `repo:${repository.fullName} type:issue created:>=${sinceDate}`,
+        ),
+        this.getRecentSearchCount(
+          `repo:${repository.fullName} type:pr created:>=${sinceDate}`,
+        ),
+      ]);
+
+    const dependencyFiles = this.extractDependencyFiles(fileTree);
+
+    const breakdown: AnalyzerBreakdown = {
+      stars: repoDetails.stargazers_count || 0,
+      forks: repoDetails.forks_count || 0,
+      contributors,
+      recentCommits30d: recentCommits,
+      recentIssues30d: recentIssues,
+      recentPrs30d: recentPrs,
+      languages: Object.keys(languages || {}),
+      fileCount: fileTree.length,
+      dependencyFiles,
+    };
+
+    const metrics = this.computeMetrics(breakdown);
+
+    const limitations: string[] = [];
+    if (!this.githubToken) {
+      limitations.push(
+        'No GITHUB_ACCESS_TOKEN configured. Unauthenticated requests have lower rate limits.',
+      );
+    }
+    if (breakdown.fileCount === 0) {
+      limitations.push('Repository tree could not be resolved fully.');
+    }
+    if (breakdown.recentCommits30d === 0) {
+      limitations.push('No commits detected in the recent analysis window.');
+    }
+
+    const report: AnalyzerReport = {
+      owner: repository.owner,
+      repo: repository.repo,
+      fullName: repository.fullName,
+      url: repository.url,
+      generatedAt: new Date().toISOString(),
+      status: limitations.length > 0 ? 'partial' : 'success',
+      metrics,
+      breakdown,
+      limitations,
+    };
+
+    this.cacheService.set(cacheKey, report, ANALYZER_CACHE_TTL_SECONDS);
+    return report;
+  }
+
+  private computeMetrics(breakdown: AnalyzerBreakdown): AnalyzerMetrics {
+    const activityScore = this.computeActivityScore(breakdown);
+    const complexityScore = this.computeComplexityScore(breakdown);
+    const learningDifficulty = this.classifyDifficulty(
+      activityScore,
+      complexityScore,
+    );
+
+    return {
+      activityScore,
+      complexityScore,
+      learningDifficulty,
+    };
+  }
+
+  // Activity favors steady maintenance signals over absolute popularity.
+  private computeActivityScore(breakdown: AnalyzerBreakdown): number {
+    const commitsScore = Math.min(35, breakdown.recentCommits30d * 0.9);
+    const contributorsScore = Math.min(20, breakdown.contributors * 2.2);
+    const issuesScore = Math.min(20, breakdown.recentIssues30d * 1.2);
+    const prsScore = Math.min(25, breakdown.recentPrs30d * 1.4);
+
+    return Math.round(commitsScore + contributorsScore + issuesScore + prsScore);
+  }
+
+  // Complexity emphasizes breadth (files/languages/dependencies) over stars.
+  private computeComplexityScore(breakdown: AnalyzerBreakdown): number {
+    const fileCountScore = Math.min(40, Math.log10(breakdown.fileCount + 1) * 14);
+    const languageDiversityScore = Math.min(25, breakdown.languages.length * 5);
+    const dependencyScore = Math.min(25, breakdown.dependencyFiles.length * 6);
+    const popularityBonus = Math.min(10, Math.log10(breakdown.stars + 1) * 4);
+
+    return Math.round(
+      fileCountScore +
+        languageDiversityScore +
+        dependencyScore +
+        popularityBonus,
+    );
+  }
+
+  private classifyDifficulty(
+    activityScore: number,
+    complexityScore: number,
+  ): DifficultyLevel {
+    const weighted = activityScore * 0.45 + complexityScore * 0.55;
+
+    if (weighted < 35) {
+      return 'Beginner';
+    }
+    if (weighted < 65) {
+      return 'Intermediate';
+    }
+    return 'Advanced';
+  }
+
+  private createFailedReport(
+    repository: AnalyzerInputRepository,
+    errorMessage: string,
+  ): AnalyzerReport {
+    return {
+      owner: repository.owner,
+      repo: repository.repo,
+      fullName: repository.fullName,
+      url: repository.url,
+      generatedAt: new Date().toISOString(),
+      status: 'failed',
+      metrics: {
+        activityScore: 0,
+        complexityScore: 0,
+        learningDifficulty: 'Beginner',
+      },
+      breakdown: {
+        stars: 0,
+        forks: 0,
+        contributors: 0,
+        recentCommits30d: 0,
+        recentIssues30d: 0,
+        recentPrs30d: 0,
+        languages: [],
+        fileCount: 0,
+        dependencyFiles: [],
+      },
+      limitations: ['Repository data could not be retrieved.'],
+      errorMessage,
+    };
+  }
+
+  private parseRepositoryUrl(url: string): AnalyzerInputRepository {
+    const raw = (url || '').trim();
+
+    const ghRegex = /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+)\/?/i;
+    const match = raw.match(ghRegex);
+    if (!match) {
+      throw new BadRequestException(`Invalid GitHub repository URL: ${url}`);
+    }
+
+    const owner = match[1];
+    const repo = match[2].replace(/\.git$/i, '');
+
+    return {
+      owner,
+      repo,
+      fullName: `${owner}/${repo}`,
+      url: `https://github.com/${owner}/${repo}`,
+    };
+  }
+
+  private async githubRequest<T>(
+    path: string,
+    config?: AxiosRequestConfig,
+  ): Promise<T> {
+    const headers = {
+      ...(config?.headers || {}),
+      ...(this.githubToken
+        ? { Authorization: `token ${this.githubToken}` }
+        : undefined),
+      Accept: 'application/vnd.github+json',
+    } as Record<string, string>;
+
+    try {
+      const response = await axios.get<T>(`${GITHUB_API_BASE}${path}`, {
+        ...config,
+        headers,
+      });
+      return response.data;
+    } catch (error) {
+      const status = error?.response?.status;
+      const remaining = error?.response?.headers?.['x-ratelimit-remaining'];
+      const reset = error?.response?.headers?.['x-ratelimit-reset'];
+
+      if (status === 403 && remaining === '0') {
+        const resetAt = reset
+          ? new Date(parseInt(reset, 10) * 1000).toISOString()
+          : 'unknown';
+        throw new Error(`GitHub rate limit exhausted. Reset at ${resetAt}`);
+      }
+
+      const message =
+        error?.response?.data?.message || error?.message || 'GitHub request failed';
+      throw new Error(message);
+    }
+  }
+
+  private async getRecentCommitCount(
+    owner: string,
+    repo: string,
+    sinceIso: string,
+  ): Promise<number> {
+    let page = 1;
+    let total = 0;
+    const since = sinceIso;
+    const maxPages = this.githubToken ? 10 : 1;
+
+    while (true) {
+      const commits = await this.githubRequest<any[]>(
+        `/repos/${owner}/${repo}/commits?since=${since}&per_page=100&page=${page}`,
+      );
+
+      total += commits.length;
+      if (commits.length < 100) break;
+      if (page >= maxPages) break;
+      page += 1;
+    }
+
+    return total;
+  }
+
+  private async getRecentSearchCount(query: string): Promise<number> {
+    try {
+      const response = await this.githubRequest<{ total_count: number }>(
+        `/search/issues?q=${encodeURIComponent(query)}&per_page=1`,
+      );
+      return response.total_count || 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  private async getContributorCount(owner: string, repo: string): Promise<number> {
+    try {
+      const headers: Record<string, string> = {
+        ...(this.githubToken
+          ? { Authorization: `token ${this.githubToken}` }
+          : undefined),
+        Accept: 'application/vnd.github+json',
+      };
+      const response = await axios.get(
+        `${GITHUB_API_BASE}/repos/${owner}/${repo}/contributors?anon=true&per_page=1`,
+        { headers },
+      );
+
+      const linkHeader = response.headers?.link;
+      if (!linkHeader) {
+        return Array.isArray(response.data) ? response.data.length : 0;
+      }
+
+      const lastMatch = /[?&]page=(\d+)>; rel="last"/.exec(linkHeader);
+      if (!lastMatch) {
+        return Array.isArray(response.data) ? response.data.length : 0;
+      }
+
+      return parseInt(lastMatch[1], 10) || 0;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch contributors count for ${owner}/${repo}: ${error.message}`,
+      );
+      return 0;
+    }
+  }
+
+  private async getRepositoryTree(
+    owner: string,
+    repo: string,
+    branch?: string,
+  ): Promise<string[]> {
+    try {
+      const targetBranch = branch || 'main';
+      const treeResponse = await this.githubRequest<{ tree: Array<{ path: string; type: string }> }>(
+        `/repos/${owner}/${repo}/git/trees/${targetBranch}?recursive=1`,
+      );
+
+      return (treeResponse.tree || [])
+        .filter((entry) => entry.type === 'blob')
+        .map((entry) => entry.path);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to fetch tree for ${owner}/${repo}: ${error.message}`,
+      );
+      return [];
+    }
+  }
+
+  private extractDependencyFiles(paths: string[]): string[] {
+    const known = [
+      'package.json',
+      'package-lock.json',
+      'yarn.lock',
+      'pnpm-lock.yaml',
+      'requirements.txt',
+      'pyproject.toml',
+      'Pipfile',
+      'poetry.lock',
+      'pom.xml',
+      'build.gradle',
+      'build.gradle.kts',
+      'go.mod',
+      'Cargo.toml',
+      'Gemfile',
+      'composer.json',
+    ];
+
+    return known.filter((file) => paths.some((path) => path.endsWith(file)));
+  }
+
+  private getSinceDateISO(): string {
+    const now = new Date();
+    now.setUTCDate(now.getUTCDate() - RECENT_WINDOW_DAYS);
+    return now.toISOString();
+  }
+
+  private getIncrementalSinceISO(fullName: string): string {
+    const baseline = this.getSinceDateISO();
+    const cursor = this.storeService.getRepoCursor(fullName);
+    if (!cursor) {
+      return baseline;
+    }
+
+    const cursorDate = new Date(cursor);
+    const baselineDate = new Date(baseline);
+    if (isNaN(cursorDate.getTime())) {
+      return baseline;
+    }
+
+    return cursorDate > baselineDate ? cursorDate.toISOString() : baseline;
+  }
+
+  private async safe<T>(fn: () => Promise<T>): Promise<T | null> {
+    try {
+      return await fn();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/webiu-server/src/analyzer/analyzer.store.service.ts
+++ b/webiu-server/src/analyzer/analyzer.store.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import {
+  AnalyzerPersistedState,
+  AnalyzerReport,
+  AnalyzerSyncRun,
+} from './types';
+
+const DEFAULT_STORE_PATH = '.analyzer/reports.json';
+
+@Injectable()
+export class AnalyzerStoreService {
+  private readonly logger = new Logger(AnalyzerStoreService.name);
+  private readonly storePath: string;
+  private state: AnalyzerPersistedState;
+
+  constructor(private configService: ConfigService) {
+    const configured =
+      this.configService.get<string>('ANALYZER_STORE_PATH') || DEFAULT_STORE_PATH;
+    this.storePath = resolve(process.cwd(), configured);
+    this.state = this.loadState();
+  }
+
+  getReports(): AnalyzerReport[] {
+    return this.state.reports;
+  }
+
+  getReport(owner: string, repo: string): AnalyzerReport | undefined {
+    return this.state.reports.find(
+      (report) => report.owner === owner && report.repo === repo,
+    );
+  }
+
+  saveReport(report: AnalyzerReport): void {
+    const index = this.state.reports.findIndex(
+      (existing) =>
+        existing.owner === report.owner && existing.repo === report.repo,
+    );
+
+    if (index >= 0) {
+      this.state.reports[index] = report;
+    } else {
+      this.state.reports.push(report);
+    }
+
+    this.persist();
+  }
+
+  setRepoCursor(fullName: string, isoTimestamp: string): void {
+    this.state.repoSyncCursor[fullName] = isoTimestamp;
+    this.persist();
+  }
+
+  getRepoCursor(fullName: string): string | undefined {
+    return this.state.repoSyncCursor[fullName];
+  }
+
+  getSyncHistory(limit = 20): AnalyzerSyncRun[] {
+    return this.state.syncHistory.slice(-limit).reverse();
+  }
+
+  createSyncRun(total: number): AnalyzerSyncRun {
+    const syncRun: AnalyzerSyncRun = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+      startedAt: new Date().toISOString(),
+      status: 'running',
+      repositoriesTotal: total,
+      repositoriesSucceeded: 0,
+      repositoriesFailed: 0,
+      errors: [],
+    };
+
+    this.state.syncHistory.push(syncRun);
+    this.persist();
+    return syncRun;
+  }
+
+  updateSyncRun(syncRun: AnalyzerSyncRun): void {
+    const index = this.state.syncHistory.findIndex((run) => run.id === syncRun.id);
+    if (index >= 0) {
+      this.state.syncHistory[index] = syncRun;
+      this.persist();
+    }
+  }
+
+  private loadState(): AnalyzerPersistedState {
+    try {
+      if (!existsSync(this.storePath)) {
+        mkdirSync(dirname(this.storePath), { recursive: true });
+        const initialState: AnalyzerPersistedState = {
+          reports: [],
+          syncHistory: [],
+          repoSyncCursor: {},
+        };
+        writeFileSync(this.storePath, JSON.stringify(initialState, null, 2));
+        return initialState;
+      }
+
+      const raw = readFileSync(this.storePath, 'utf-8');
+      const parsed = JSON.parse(raw) as AnalyzerPersistedState;
+
+      return {
+        reports: parsed.reports || [],
+        syncHistory: parsed.syncHistory || [],
+        repoSyncCursor: parsed.repoSyncCursor || {},
+      };
+    } catch (error) {
+      this.logger.error(`Failed to read analyzer store at ${this.storePath}`);
+      this.logger.error(error?.message || String(error));
+      return {
+        reports: [],
+        syncHistory: [],
+        repoSyncCursor: {},
+      };
+    }
+  }
+
+  private persist(): void {
+    try {
+      mkdirSync(dirname(this.storePath), { recursive: true });
+      writeFileSync(this.storePath, JSON.stringify(this.state, null, 2));
+    } catch (error) {
+      this.logger.error(`Failed to persist analyzer store at ${this.storePath}`);
+      this.logger.error(error?.message || String(error));
+    }
+  }
+}

--- a/webiu-server/src/analyzer/cli.ts
+++ b/webiu-server/src/analyzer/cli.ts
@@ -1,0 +1,79 @@
+import { NestFactory } from '@nestjs/core';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { AppModule } from '../app.module';
+import { AnalyzerService } from './analyzer.service';
+
+interface CliArgs {
+  repos: string[];
+  outputPath: string;
+  forceRefresh: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const repos: string[] = [];
+  let outputPath = 'docs/examples/analyzer-report.json';
+  let forceRefresh = true;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repos') {
+      const value = argv[i + 1] || '';
+      value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .forEach((repo) => repos.push(repo));
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--output') {
+      outputPath = argv[i + 1] || outputPath;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--no-force-refresh') {
+      forceRefresh = false;
+      continue;
+    }
+  }
+
+  return { repos, outputPath, forceRefresh };
+}
+
+async function run(): Promise<void> {
+  const { repos, outputPath, forceRefresh } = parseArgs(process.argv.slice(2));
+  if (repos.length === 0) {
+    throw new Error(
+      'No repositories provided. Use --repos with comma-separated GitHub URLs.',
+    );
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+
+  try {
+    const analyzerService = app.get(AnalyzerService);
+    const result = await analyzerService.analyzeRepositories(repos, {
+      forceRefresh,
+      persist: true,
+    });
+
+    const resolvedPath = resolve(process.cwd(), outputPath);
+    mkdirSync(dirname(resolvedPath), { recursive: true });
+    writeFileSync(resolvedPath, JSON.stringify(result, null, 2));
+
+    console.log(`Analyzer report saved to ${resolvedPath}`);
+    console.log(`Reports generated: ${result.reports.length}`);
+  } finally {
+    await app.close();
+  }
+}
+
+run().catch((error) => {
+  console.error(error?.message || String(error));
+  process.exit(1);
+});

--- a/webiu-server/src/analyzer/dto/analyze-request.dto.ts
+++ b/webiu-server/src/analyzer/dto/analyze-request.dto.ts
@@ -1,0 +1,18 @@
+import {
+  IsArray,
+  ArrayNotEmpty,
+  IsString,
+  IsOptional,
+  IsBoolean,
+} from 'class-validator';
+
+export class AnalyzeRequestDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  repositories: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  forceRefresh?: boolean;
+}

--- a/webiu-server/src/analyzer/dto/report-query.dto.ts
+++ b/webiu-server/src/analyzer/dto/report-query.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ReportQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/webiu-server/src/analyzer/types.ts
+++ b/webiu-server/src/analyzer/types.ts
@@ -1,0 +1,59 @@
+export type DifficultyLevel = 'Beginner' | 'Intermediate' | 'Advanced';
+
+export interface AnalyzerInputRepository {
+  owner: string;
+  repo: string;
+  fullName: string;
+  url: string;
+}
+
+export interface AnalyzerMetrics {
+  activityScore: number;
+  complexityScore: number;
+  learningDifficulty: DifficultyLevel;
+}
+
+export interface AnalyzerBreakdown {
+  stars: number;
+  forks: number;
+  contributors: number;
+  recentCommits30d: number;
+  recentIssues30d: number;
+  recentPrs30d: number;
+  languages: string[];
+  fileCount: number;
+  dependencyFiles: string[];
+}
+
+export type AnalyzerStatus = 'success' | 'partial' | 'failed';
+
+export interface AnalyzerReport {
+  owner: string;
+  repo: string;
+  fullName: string;
+  url: string;
+  generatedAt: string;
+  status: AnalyzerStatus;
+  metrics: AnalyzerMetrics;
+  breakdown: AnalyzerBreakdown;
+  limitations: string[];
+  errorMessage?: string;
+}
+
+export interface AnalyzerPersistedState {
+  reports: AnalyzerReport[];
+  syncHistory: AnalyzerSyncRun[];
+  repoSyncCursor: Record<string, string>;
+}
+
+export interface AnalyzerSyncRun {
+  id: string;
+  startedAt: string;
+  endedAt?: string;
+  status: 'running' | 'completed' | 'partial' | 'failed';
+  repositoriesTotal: number;
+  repositoriesSucceeded: number;
+  repositoriesFailed: number;
+  rateLimitRemaining?: number;
+  errors: Array<{ repository: string; message: string }>;
+}

--- a/webiu-server/src/app.module.ts
+++ b/webiu-server/src/app.module.ts
@@ -14,6 +14,7 @@ import { ProjectModule } from './project/project.module';
 import { ContributorModule } from './contributor/contributor.module';
 import { UserModule } from './user/user.module';
 import { GraphqlResolversModule } from './graphql/graphql.module';
+import { AnalyzerModule } from './analyzer/analyzer.module';
 
 @Module({
   imports: [
@@ -53,6 +54,7 @@ import { GraphqlResolversModule } from './graphql/graphql.module';
     ProjectModule,
     ContributorModule,
     UserModule,
+    AnalyzerModule,
   ],
   controllers: [AppController],
   providers: [


### PR DESCRIPTION
## Summary
This PR implements the GitHub Repository Intelligence Analyzer requested in Issue #540, including design documentation and backend implementation.

## What is included
1. Analyzer backend module with REST APIs:
   - `POST /api/analyzer/analyze`
   - `POST /api/analyzer/sync`
   - `GET /api/analyzer/reports`
   - `GET /api/analyzer/reports/:owner/:repo`
   - `GET /api/analyzer/sync-history`
2. Analysis engine:
   - Activity score from commits/contributors/issues/PRs
   - Complexity score from file count/language diversity/dependency files/popularity
   - Learning difficulty classification: Beginner / Intermediate / Advanced
3. Scheduled sync + persistence:
   - Scheduler-driven refresh with configurable interval
   - Incremental sync cursor per repository
   - JSON-backed persistent report store
4. CLI support:
   - `npm run analyzer:run` to analyze repository URL batches
5. Tests:
   - Analyzer service unit tests
   - Analyzer controller unit tests
6. Documentation updates:
   - API contract + formulas + assumptions
   - Architecture updates and analyzer component details
   - README run instructions and deployment paths (Fly.io + Railway fallback)

## Files to review first
- `webiu-server/src/analyzer/analyzer.service.ts`
- `webiu-server/src/analyzer/analyzer.controller.ts`
- `webiu-server/src/analyzer/analyzer.controller.spec.ts`
- `docs/API_DOCUMENTATION.md`
- `docs/ARCHITECTURE.md`
- `README.md`

## Validation
- `npm run build` (webiu-server) ✅
- `npm test -- analyzer.service.spec.ts --runInBand` ✅
- `npm test -- analyzer.controller.spec.ts --runInBand` ✅

## Sample output
- `docs/examples/analyzer-sample-report.json`

## Deployment status
- Fly.io config is included (`webiu-server/fly.toml`), but live app creation is blocked on account billing.
- Railway fallback path is now documented in README and can be used to publish the live URL immediately.

Railway deploy commands:
```bash
cd webiu-server
railway login
railway init
railway up
```

Expected URL format to add after deploy:
- `https://<your-railway-domain>`