### PR TITLE
fix(project): enforce 300s TTL in getIssuesAndPr cache

### DIFF
--- a/webiu-server/src/project/project.service.spec.ts
+++ b/webiu-server/src/project/project.service.spec.ts
@@ -128,11 +128,17 @@ describe('ProjectService', () => {
 
     it('should cache the result', async () => {
       mockGithubService.getRepoIssues.mockResolvedValue([]);
+      const cacheSetSpy = jest.spyOn(cacheService, 'set');
 
       await service.getIssuesAndPr('c2siorg', 'repo1');
       await service.getIssuesAndPr('c2siorg', 'repo1');
 
       expect(mockGithubService.getRepoIssues).toHaveBeenCalledTimes(1);
+      expect(cacheSetSpy).toHaveBeenCalledWith(
+        'issues_pr_count_c2siorg_repo1',
+        { issues: 0, pullRequests: 0 },
+        300,
+      );
     });
 
     it('should throw BadRequestException when org is missing', async () => {

--- a/webiu-server/src/project/project.service.ts
+++ b/webiu-server/src/project/project.service.ts
@@ -87,7 +87,7 @@ export class ProjectService {
       const pullRequests = data.filter((item) => item.pull_request).length;
 
       const result = { issues, pullRequests };
-      this.cacheService.set(cacheKey, result);
+      this.cacheService.set(cacheKey, result, CACHE_TTL);
       return result;
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
## Summary
This PR fixes a TTL inconsistency in `ProjectService#getIssuesAndPr` cache behavior.

## Problem
`getIssuesAndPr()` was caching repository issue/PR counts without explicitly passing `CACHE_TTL`, while other `ProjectService` cache writes use `CACHE_TTL = 300`.

This could lead to stale issue/PR counts being served longer than intended.

## Fix
Updated cache write in `getIssuesAndPr()` to pass TTL:

- Before: `this.cacheService.set(cacheKey, result)`
- After: `this.cacheService.set(cacheKey, result, CACHE_TTL)`

## Test Coverage
Added assertion in `project.service.spec.ts` to verify cache write includes TTL `300` for `getIssuesAndPr`.

## Files changed
- `webiu-server/src/project/project.service.ts`
- `webiu-server/src/project/project.service.spec.ts`

## Validation
- `npm test -- project.service.spec.ts --runInBand` ✅
