### PR TITLE
feat(auth-ui): add registration, email verification, and admin access integration tests

### DIFF
--- a/webiu-ui/package-lock.json
+++ b/webiu-ui/package-lock.json
@@ -473,6 +473,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -826,6 +827,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -926,7 +928,6 @@
       "integrity": "sha512-1KocmjmBP0qlKQGRhRGN0MGvLxf1q2KDWbvzn7ZGdQrIDLC/hFJ8YmnOWsPrM9RxiZi0o5BxCCu9D7KlbthxIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "21.0.1",
         "eslint-scope": "^9.0.0"
@@ -956,7 +957,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.12.tgz",
       "integrity": "sha512-9hsdWF4gRRcVJtPcCcYLaX1CIyM9wUu6r+xRl6zU5hq8qhl35hig6ounz7CXFAzLf0WDBdM16bPHouVGaG76lg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1007,7 +1007,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.12.tgz",
       "integrity": "sha512-vabJzvrx76XXFrm1RJZ6o/CyG32piTB/1sfFfKHdlH1QrmArb8It4gyk9oEjZ1IkAD0HvBWlfWmn+T6Vx3pdUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1024,7 +1023,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.12.tgz",
       "integrity": "sha512-vwI8oOL/gM+wPnptOVeBbMfZYwzRxQsovojZf+Zol9szl0k3SZ3FycWlxxXZGFu3VIEfrP6pXplTmyODS/Lt1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1046,7 +1044,6 @@
       "integrity": "sha512-1F8M7nWfChzurb7obbvuE7mJXlHtY1UG58pcwcomVtpPb+kPavgAO8OEvJHYBMV+bzSxkXt5UIwL9lt9jHUxZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.23.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1123,7 +1120,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.12.tgz",
       "integrity": "sha512-MuFt5yKi161JmauUta4Dh0m8ofwoq6Ino+KoOtkYMBGsSx+A7dSm+DUxxNwdj7+DNyg3LjVGCFgBFnq4g8z06A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1158,7 +1154,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.12.tgz",
       "integrity": "sha512-DYY04ptWh/ulMHzd+y52WCE8QnEYGeIiW3hEIFjCN8z0kbIdFdUtEB0IK5vjNL3ejyhUmphcpeT5PYf3YXtqWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1199,7 +1194,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-17.3.12.tgz",
       "integrity": "sha512-P3xBzyeT2w/iiGsqGUNuLRYdqs2e+5nRnVYU9tc/TjhYDAgwEgq946U7Nie1xq5Ts/8b7bhxcK9maPKWG237Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0",
         "xhr2": "^0.2.0"
@@ -1238,7 +1232,6 @@
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-17.3.12.tgz",
       "integrity": "sha512-Y83+oTZ2XPO7P2Yok78JNlXDDXbP7Qr+HN6ifpPXWmUS4MwFEyXByCl3Hlz9VMxnrKvPYWvzHKWfT0S20XZsvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1298,7 +1291,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -5005,7 +4997,6 @@
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5760,7 +5751,6 @@
       "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5816,7 +5806,6 @@
       "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -6090,7 +6079,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6177,7 +6165,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -6518,6 +6505,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -7066,7 +7054,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8637,7 +8624,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10697,8 +10683,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.1.2.tgz",
       "integrity": "sha512-2oIUMGn00FdUiqz6epiiJr7xcFyNYj3rDcfmnzfkBnHyBQ3cBQUs4mmyGsOb7TTLb9kxk7dBcmEmqhDKkBoDyA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
@@ -10956,7 +10941,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -11264,7 +11248,6 @@
       "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13399,7 +13382,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -14157,7 +14139,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14212,7 +14193,6 @@
       "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -15585,7 +15565,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15600,7 +15579,6 @@
       "integrity": "sha512-KALyxkpYV5Ix7UhvjTwJXZv76VWsHG+NjNlt/z+a17SOQSiOcBdUXdbJdyXi7RPxrBFECtFOiPwUJQusJuCqrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.46.4",
         "@typescript-eslint/parser": "8.46.4",
@@ -16589,7 +16567,6 @@
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -16807,7 +16784,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17122,8 +17098,7 @@
       "version": "0.14.10",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.10.tgz",
       "integrity": "sha512-YGAhaO7J5ywOXW6InXNlLmfU194F8lVgu7bRntUF3TiG8Y3nBK0x1UJJuHUP/e8IyihkjCYqhCScpSwnlaSRkQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/webiu-ui/src/app/app.config.ts
+++ b/webiu-ui/src/app/app.config.ts
@@ -1,14 +1,19 @@
 import { ApplicationConfig, isDevMode } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient, withFetch } from '@angular/common/http';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from '@angular/common/http';
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideServiceWorker } from '@angular/service-worker';
+import { authInterceptor } from './interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
     provideClientHydration(),
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),

--- a/webiu-ui/src/app/app.routes.ts
+++ b/webiu-ui/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes, RouterModule } from '@angular/router';
+import { adminGuard } from './guards/admin.guard';
 
 export const routes: Routes = [
   {
@@ -67,6 +68,33 @@ export const routes: Routes = [
     loadComponent: () =>
       import('./page/contributor-search/contributor-search.component').then(
         (m) => m.ContributorSearchComponent,
+      ),
+  },
+  {
+    path: 'login',
+    loadComponent: () =>
+      import('./page/login/login.component').then((m) => m.LoginComponent),
+  },
+  {
+    path: 'register',
+    loadComponent: () =>
+      import('./page/register/register.component').then(
+        (m) => m.RegisterComponent,
+      ),
+  },
+  {
+    path: 'auth/verify-email',
+    loadComponent: () =>
+      import('./page/email-verification/email-verification.component').then(
+        (m) => m.EmailVerificationComponent,
+      ),
+  },
+  {
+    path: 'admin',
+    canActivate: [adminGuard],
+    loadComponent: () =>
+      import('./page/admin-dashboard/admin-dashboard.component').then(
+        (m) => m.AdminDashboardComponent,
       ),
   },
   {

--- a/webiu-ui/src/app/components/navbar/navbar.component.html
+++ b/webiu-ui/src/app/components/navbar/navbar.component.html
@@ -115,6 +115,22 @@
       <img src="../../../assets/community.svg" alt="Community Icon" class="menu-icon" />
       <p>Community</p>
     </div>
+    @if (isAdmin) {
+      <div
+        class="navbar__menu__items"
+        routerLink="/admin"
+        [class.active]="isRouteActive('/admin')"
+        (click)="navigateToAdmin()"
+        (keydown.enter)="navigateToAdmin()"
+        (keydown.space)="navigateToAdmin(); $event.preventDefault()"
+        tabindex="0"
+        role="link"
+        [attr.aria-label]="'Admin Dashboard'"
+      >
+        <img src="../../../assets/projects.svg" alt="Admin Icon" class="menu-icon" />
+        <p>Admin</p>
+      </div>
+    }
     <div
       class="navbar__menu__items"
       routerLink="/gsoc"
@@ -149,12 +165,20 @@
     @if (isLoggedIn) {
       <p class="welcome-text">
         Welcome,<br />
-        {{ user.name }}!
+        {{ user?.name }}!
       </p>
     }
 
     @if (showLoginOptions && !isLoggedIn) {
       <div class="login-options">
+        <button type="button" (click)="navigateToLogin()">
+          <img src="../../../assets/login.svg" alt="Login Icon" />
+          <p>Login with Email</p>
+        </button>
+        <button type="button" (click)="navigateToRegister()">
+          <img src="../../../assets/login.svg" alt="Register Icon" />
+          <p>Create Account</p>
+        </button>
         <button type="button" (click)="loginWithGoogle()">
           <img src="../../../assets/google.webp" alt="Google Icon" />
           <p>Login with Google</p>

--- a/webiu-ui/src/app/components/navbar/navbar.component.ts
+++ b/webiu-ui/src/app/components/navbar/navbar.component.ts
@@ -1,9 +1,18 @@
-import { Component, HostListener, OnInit, inject, PLATFORM_ID } from '@angular/core';
+import {
+  Component,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  inject,
+  PLATFORM_ID,
+} from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Router, RouterModule, NavigationEnd } from '@angular/router';
 import { ThemeService } from '../../services/theme.service';
 import { filter } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { AuthService, AuthUser } from '../../services/auth.service';
 
 @Component({
   selector: 'app-navbar',
@@ -16,42 +25,53 @@ export class NavbarComponent implements OnInit {
   private router = inject(Router);
   private themeService = inject(ThemeService);
   private platformId = inject(PLATFORM_ID);
+  private authService = inject(AuthService);
+  private subscriptions = new Subscription();
 
   isMenuOpen = false;
   isSunVisible = true;
   isLoggedIn = false;
+  isAdmin = false;
   showLoginOptions = false;
-  user: any;
+  user: AuthUser | null = null;
   currentRoute = '/';
 
   ngOnInit(): void {
     this.isSunVisible = !this.themeService.isDarkMode();
-    this.router.events
-      .pipe(
-        filter(
-          (event): event is NavigationEnd => event instanceof NavigationEnd,
-        ),
-      )
-      .subscribe((event: NavigationEnd) => {
-        this.currentRoute = event.url;
-        this.isMenuOpen = false;
-      });
+    this.subscriptions.add(
+      this.router.events
+        .pipe(
+          filter(
+            (event): event is NavigationEnd => event instanceof NavigationEnd,
+          ),
+        )
+        .subscribe((event: NavigationEnd) => {
+          this.currentRoute = event.url;
+          this.isMenuOpen = false;
+          this.showLoginOptions = false;
+        }),
+    );
+
+    this.subscriptions.add(
+      this.authService.authSession$.subscribe((session) => {
+        this.user = session?.user ?? null;
+        this.isLoggedIn = !!session;
+        this.isAdmin = this.authService.isAdmin;
+      }),
+    );
 
     if (isPlatformBrowser(this.platformId)) {
-      const queryParams = new URLSearchParams(window.location.search);
-      const user = queryParams.get('user');
-      if (user) {
-        try {
-          this.user = JSON.parse(decodeURIComponent(user));
-          this.isLoggedIn = true;
-        } catch (e) {
-          console.warn('Failed to parse user query param:', e);
-          this.user = null;
-          this.isLoggedIn = false;
-        }
+      const didConsumeOAuthQuery = this.authService.consumeOAuthUserFromUrl(
+        window.location.search,
+      );
+      if (didConsumeOAuthQuery) {
         window.history.replaceState({}, document.title, window.location.pathname);
       }
     }
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
   }
 
   toggleLoginOptions(): void {
@@ -80,8 +100,23 @@ export class NavbarComponent implements OnInit {
   }
 
   logout(): void {
-    this.isLoggedIn = false;
-    this.user = null;
+    this.authService.logout();
+    this.showLoginOptions = false;
+  }
+
+  navigateToLogin(): void {
+    this.showLoginOptions = false;
+    this.router.navigate(['/login']);
+  }
+
+  navigateToRegister(): void {
+    this.showLoginOptions = false;
+    this.router.navigate(['/register']);
+  }
+
+  navigateToAdmin(): void {
+    this.router.navigate(['/admin']);
+    this.closeMenu();
   }
 
   loginWithGoogle(): void {
@@ -134,7 +169,7 @@ export class NavbarComponent implements OnInit {
   }
 
   isRouteActive(route: string): boolean {
-    return this.currentRoute === route;
+    return this.currentRoute.split('?')[0] === route;
   }
 
   navigateTo(route: string): void {

--- a/webiu-ui/src/app/guards/admin.guard.spec.ts
+++ b/webiu-ui/src/app/guards/admin.guard.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+import { adminGuard } from './admin.guard';
+
+describe('adminGuard', () => {
+  let authService: {
+    isAuthenticated: boolean;
+    isAdmin: boolean;
+  };
+  let router: Router;
+
+  beforeEach(() => {
+    authService = {
+      isAuthenticated: false,
+      isAdmin: false,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([]), { provide: AuthService, useValue: authService }],
+    });
+
+    router = TestBed.inject(Router);
+  });
+
+  it('redirects unauthenticated users to login with returnUrl', () => {
+    const result = TestBed.runInInjectionContext(() =>
+      adminGuard({} as never, { url: '/admin' } as never),
+    );
+
+    expect(result instanceof UrlTree).toBeTrue();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/login?returnUrl=%2Fadmin');
+  });
+
+  it('redirects authenticated non-admin users to home', () => {
+    authService.isAuthenticated = true;
+    authService.isAdmin = false;
+
+    const result = TestBed.runInInjectionContext(() =>
+      adminGuard({} as never, { url: '/admin' } as never),
+    );
+
+    expect(result instanceof UrlTree).toBeTrue();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/');
+  });
+
+  it('allows admin users', () => {
+    authService.isAuthenticated = true;
+    authService.isAdmin = true;
+
+    const result = TestBed.runInInjectionContext(() =>
+      adminGuard({} as never, { url: '/admin' } as never),
+    );
+
+    expect(result).toBeTrue();
+  });
+});

--- a/webiu-ui/src/app/guards/admin.guard.ts
+++ b/webiu-ui/src/app/guards/admin.guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const adminGuard: CanActivateFn = (_route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated) {
+    return router.createUrlTree(['/login'], {
+      queryParams: { returnUrl: state.url },
+    });
+  }
+
+  if (!authService.isAdmin) {
+    return router.createUrlTree(['/']);
+  }
+
+  return true;
+};

--- a/webiu-ui/src/app/interceptors/auth.interceptor.ts
+++ b/webiu-ui/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,20 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const token = authService.accessToken;
+
+  if (!token) {
+    return next(req);
+  }
+
+  return next(
+    req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`,
+      },
+    }),
+  );
+};

--- a/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.html
+++ b/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.html
@@ -1,0 +1,46 @@
+<main class="admin-page">
+  <header class="admin-header">
+    <p class="eyebrow">Admin Console</p>
+    <h1>WebIU Control Center</h1>
+    <p class="subtitle">
+      Signed in as {{ user?.name }} ({{ user?.email }}). This page is protected and only available to admins.
+    </p>
+  </header>
+
+  @if (loading) {
+    <section class="state-panel">
+      <p>Loading dashboard data...</p>
+    </section>
+  } @else if (errorMessage) {
+    <section class="state-panel error">
+      <p>{{ errorMessage }}</p>
+    </section>
+  } @else {
+    <section class="admin-grid">
+      @for (stat of dashboard?.stats; track stat.label) {
+        <article class="admin-card">
+          <p class="status">Live Metric</p>
+          <h2>{{ stat.value }}</h2>
+          <p>{{ stat.label }}</p>
+        </article>
+      }
+    </section>
+
+    <section class="activity-section">
+      <h2>Recent Activity</h2>
+
+      @if (dashboard?.recentActivity?.length) {
+        <div class="activity-list">
+          @for (item of dashboard?.recentActivity; track item.url) {
+            <article class="activity-item">
+              <p class="activity-meta">{{ item.type }} by {{ item.author }} - {{ item.state }}</p>
+              <a [href]="item.url" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
+            </article>
+          }
+        </div>
+      } @else {
+        <p class="empty-message">No recent activity available.</p>
+      }
+    </section>
+  }
+</main>

--- a/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.scss
+++ b/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.scss
@@ -1,0 +1,124 @@
+.admin-page {
+  padding: 40px 20px 70px;
+  background: linear-gradient(180deg, #f4fbff 0%, transparent 32%),
+    radial-gradient(circle at 80% 20%, #cae9ff 0%, transparent 36%);
+  min-height: calc(100vh - 140px);
+}
+
+.admin-header {
+  max-width: 1100px;
+  margin: 0 auto 28px;
+
+  .eyebrow {
+    margin: 0;
+    color: #0d7bdc;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: 12px;
+  }
+
+  h1 {
+    margin: 8px 0 10px;
+    color: var(--primary-dark);
+    font-size: clamp(30px, 4vw, 42px);
+  }
+
+  .subtitle {
+    margin: 0;
+    color: var(--font-light);
+    max-width: 760px;
+    line-height: 1.6;
+  }
+}
+
+.admin-grid {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.admin-card {
+  border: 1px solid var(--border-color);
+  background: var(--navbar-bg);
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.07);
+
+  .status {
+    margin: 0;
+    color: #0d7bdc;
+    font-weight: 600;
+    font-size: 13px;
+  }
+
+  h2 {
+    margin: 10px 0 10px;
+    color: var(--primary-dark);
+    font-size: 22px;
+  }
+
+  p {
+    margin: 0;
+    color: var(--font-light);
+    line-height: 1.55;
+  }
+}
+
+.state-panel {
+  max-width: 1100px;
+  margin: 0 auto;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--navbar-bg);
+  padding: 20px;
+  color: var(--font-light);
+
+  &.error {
+    border-color: #cf8f88;
+    color: #8a1e18;
+    background: #fdeeee;
+  }
+}
+
+.activity-section {
+  max-width: 1100px;
+  margin: 24px auto 0;
+
+  h2 {
+    color: var(--primary-dark);
+    margin: 0 0 12px;
+  }
+}
+
+.activity-list {
+  display: grid;
+  gap: 10px;
+}
+
+.activity-item {
+  border: 1px solid var(--border-color);
+  background: var(--navbar-bg);
+  border-radius: 10px;
+  padding: 12px;
+
+  .activity-meta {
+    margin: 0 0 6px;
+    color: var(--font-light);
+    font-size: 13px;
+    text-transform: capitalize;
+  }
+
+  a {
+    color: #0d7bdc;
+    text-decoration: none;
+    font-weight: 600;
+  }
+}
+
+.empty-message {
+  margin: 0;
+  color: var(--font-light);
+}

--- a/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.ts
+++ b/webiu-ui/src/app/page/admin-dashboard/admin-dashboard.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import {
+  AdminDashboardResponse,
+  AuthService,
+} from '../../services/auth.service';
+
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-dashboard.component.html',
+  styleUrl: './admin-dashboard.component.scss',
+})
+export class AdminDashboardComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+
+  readonly user = this.authService.currentUser;
+  loading = true;
+  errorMessage = '';
+  dashboard: AdminDashboardResponse | null = null;
+
+  ngOnInit(): void {
+    this.authService.getAdminDashboard().subscribe({
+      next: (response) => {
+        this.dashboard = response;
+        this.loading = false;
+      },
+      error: (error) => {
+        this.errorMessage =
+          error?.error?.message || 'Failed to load dashboard data.';
+        this.loading = false;
+      },
+    });
+  }
+}

--- a/webiu-ui/src/app/page/email-verification/email-verification.component.html
+++ b/webiu-ui/src/app/page/email-verification/email-verification.component.html
@@ -1,0 +1,14 @@
+<main class="verification-page">
+  <section class="verification-card">
+    <h1>Email verification</h1>
+
+    @if (loading) {
+      <p class="status neutral">{{ message }}</p>
+    } @else if (success) {
+      <p class="status success">{{ message }}</p>
+    } @else {
+      <p class="status error">{{ message }}</p>
+      <a routerLink="/login" class="retry-link">Go to login</a>
+    }
+  </section>
+</main>

--- a/webiu-ui/src/app/page/email-verification/email-verification.component.scss
+++ b/webiu-ui/src/app/page/email-verification/email-verification.component.scss
@@ -1,0 +1,49 @@
+.verification-page {
+  min-height: calc(100vh - 140px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: radial-gradient(circle at 20% 20%, #d6efff 0%, transparent 40%),
+    radial-gradient(circle at 80% 80%, #d8f9df 0%, transparent 40%),
+    var(--cards-container);
+}
+
+.verification-card {
+  width: min(100%, 560px);
+  border-radius: 14px;
+  padding: 30px;
+  border: 1px solid var(--border-color);
+  background: var(--navbar-bg);
+  box-shadow: 0 16px 36px rgba(11, 26, 45, 0.13);
+
+  h1 {
+    margin: 0 0 16px;
+    color: var(--primary-dark);
+  }
+}
+
+.status {
+  margin: 0;
+  line-height: 1.6;
+  font-size: 16px;
+
+  &.neutral {
+    color: var(--font-light);
+  }
+
+  &.success {
+    color: #13672f;
+  }
+
+  &.error {
+    color: #8a1e18;
+  }
+}
+
+.retry-link {
+  display: inline-block;
+  margin-top: 12px;
+  color: #0d7bdc;
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/webiu-ui/src/app/page/email-verification/email-verification.component.ts
+++ b/webiu-ui/src/app/page/email-verification/email-verification.component.ts
@@ -1,0 +1,49 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-email-verification',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './email-verification.component.html',
+  styleUrl: './email-verification.component.scss',
+})
+export class EmailVerificationComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  loading = true;
+  success = false;
+  message = 'Verifying your email address...';
+
+  ngOnInit(): void {
+    const token = this.route.snapshot.queryParamMap.get('token');
+    if (!token) {
+      this.loading = false;
+      this.success = false;
+      this.message = 'Verification token is missing. Please use the link from your email.';
+      return;
+    }
+
+    this.authService.verifyEmail(token).subscribe({
+      next: (response) => {
+        this.loading = false;
+        this.success = true;
+        this.message = response.message || 'Email verified successfully. Redirecting to login...';
+
+        setTimeout(() => {
+          this.router.navigate(['/login']);
+        }, 1800);
+      },
+      error: (error) => {
+        this.loading = false;
+        this.success = false;
+        this.message =
+          error?.error?.message || 'Verification failed. The token may be invalid or expired.';
+      },
+    });
+  }
+}

--- a/webiu-ui/src/app/page/login/login.component.html
+++ b/webiu-ui/src/app/page/login/login.component.html
@@ -1,0 +1,38 @@
+<main class="login-page">
+  <section class="login-card">
+    <h1>Sign in to WebIU</h1>
+    <p class="subtitle">Use your local account or continue with OAuth.</p>
+
+    @if (errorMessage) {
+      <p class="error-banner">{{ errorMessage }}</p>
+    }
+
+    <form [formGroup]="loginForm" (ngSubmit)="submitLogin()" novalidate>
+      <label for="email">Email</label>
+      <input id="email" type="email" formControlName="email" placeholder="admin@webiu.local" />
+      @if (loginForm.controls.email.touched && loginForm.controls.email.invalid) {
+        <p class="field-error">Enter a valid email address.</p>
+      }
+
+      <label for="password">Password</label>
+      <input id="password" type="password" formControlName="password" placeholder="Enter your password" />
+      @if (loginForm.controls.password.touched && loginForm.controls.password.invalid) {
+        <p class="field-error">Password must be at least 6 characters long.</p>
+      }
+
+      <button type="submit" [disabled]="loading">
+        {{ loading ? 'Signing in...' : 'Sign in' }}
+      </button>
+    </form>
+
+    <div class="oauth-actions">
+      <button type="button" class="oauth-btn" (click)="loginWithGoogle()">Continue with Google</button>
+      <button type="button" class="oauth-btn" (click)="loginWithGitHub()">Continue with GitHub</button>
+    </div>
+
+    <p class="register-link">
+      New here?
+      <a routerLink="/register">Create an account</a>
+    </p>
+  </section>
+</main>

--- a/webiu-ui/src/app/page/login/login.component.scss
+++ b/webiu-ui/src/app/page/login/login.component.scss
@@ -1,0 +1,112 @@
+.login-page {
+  min-height: calc(100vh - 140px);
+  display: grid;
+  place-items: center;
+  padding: 32px 20px;
+  background: radial-gradient(circle at top right, #d6ecff 0%, transparent 45%),
+    radial-gradient(circle at bottom left, #e7f7e8 0%, transparent 45%),
+    var(--cards-container);
+}
+
+.login-card {
+  width: min(100%, 460px);
+  border-radius: 14px;
+  background: var(--navbar-bg);
+  border: 1px solid var(--border-color);
+  padding: 28px;
+  box-shadow: 0 14px 36px rgba(17, 32, 56, 0.16);
+
+  h1 {
+    margin: 0;
+    color: var(--primary-dark);
+    font-size: 30px;
+  }
+
+  .subtitle {
+    margin: 10px 0 20px;
+    color: var(--font-light);
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  label {
+    font-weight: 600;
+    color: var(--primary-dark);
+    margin-top: 4px;
+  }
+
+  input {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 15px;
+    background: var(--cards-container);
+    color: var(--primary-dark);
+  }
+
+  button[type='submit'] {
+    margin-top: 6px;
+    background: #0d7bdc;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 11px 16px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.oauth-actions {
+  margin-top: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.oauth-btn {
+  border: 1px solid var(--border-color);
+  background: var(--cards-container);
+  color: var(--primary-dark);
+  border-radius: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover {
+    border-color: #0d7bdc;
+  }
+}
+
+.error-banner {
+  margin: 8px 0 12px;
+  border: 1px solid #e89d95;
+  background: #fde8e5;
+  color: #821a15;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.field-error {
+  margin: -4px 0 2px;
+  color: #b9382b;
+  font-size: 13px;
+}
+
+.register-link {
+  margin: 16px 0 0;
+  color: var(--font-light);
+
+  a {
+    color: #0d7bdc;
+    text-decoration: none;
+    font-weight: 600;
+  }
+}

--- a/webiu-ui/src/app/page/login/login.component.spec.ts
+++ b/webiu-ui/src/app/page/login/login.component.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { provideRouter, Router } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthService, AuthSession } from '../../services/auth.service';
+
+describe('LoginComponent auth flow', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    authService = jasmine.createSpyObj<AuthService>('AuthService', ['login']);
+
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authService },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    spyOn(router, 'parseUrl').and.returnValue({ queryParams: {} } as never);
+    spyOn(router, 'navigateByUrl').and.returnValue(
+      Promise.resolve(true),
+    );
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('navigates admin users to /admin after login', () => {
+    const session: AuthSession = {
+      accessToken: 'token',
+      tokenType: 'Bearer',
+      expiresInSeconds: 3600,
+      user: {
+        name: 'Admin',
+        email: 'admin@webiu.local',
+        role: 'admin',
+      },
+    };
+
+    authService.login.and.returnValue(
+      of<AuthSession>(session),
+    );
+
+    component.loginForm.setValue({
+      email: 'admin@webiu.local',
+      password: 'admin123',
+    });
+
+    component.submitLogin();
+
+    expect(authService.login).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/admin');
+  });
+});

--- a/webiu-ui/src/app/page/login/login.component.ts
+++ b/webiu-ui/src/app/page/login/login.component.ts
@@ -1,0 +1,72 @@
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { Component, PLATFORM_ID, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss',
+})
+export class LoginComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  loading = false;
+  errorMessage = '';
+
+  readonly loginForm = this.fb.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(6)]],
+  });
+
+  submitLogin() {
+    if (this.loginForm.invalid || this.loading) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.authService.login(this.loginForm.getRawValue() as never).subscribe({
+      next: (session) => {
+        const returnUrl = this.router.parseUrl(this.router.url).queryParams[
+          'returnUrl'
+        ];
+
+        this.router.navigateByUrl(returnUrl || (session.user.role === 'admin' ? '/admin' : '/'));
+      },
+      error: (error) => {
+        this.errorMessage =
+          error?.error?.message || 'Unable to login. Check your credentials and try again.';
+        this.loading = false;
+      },
+      complete: () => {
+        this.loading = false;
+      },
+    });
+  }
+
+  loginWithGoogle() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    window.location.href = `${environment.serverUrl}/auth/google`;
+  }
+
+  loginWithGitHub() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    window.location.href = `${environment.serverUrl}/auth/github`;
+  }
+}

--- a/webiu-ui/src/app/page/register/register.component.html
+++ b/webiu-ui/src/app/page/register/register.component.html
@@ -1,0 +1,49 @@
+<main class="register-page">
+  <section class="register-card">
+    <h1>Create your account</h1>
+    <p class="subtitle">Register with your email to access contributor and admin features.</p>
+
+    @if (errorMessage) {
+      <p class="error-banner">{{ errorMessage }}</p>
+    }
+
+    @if (successMessage) {
+      <p class="success-banner">{{ successMessage }}</p>
+    }
+
+    <form [formGroup]="registerForm" (ngSubmit)="submitRegister()" novalidate>
+      <label for="name">Name</label>
+      <input id="name" type="text" formControlName="name" placeholder="Your full name" />
+      @if (registerForm.controls.name.touched && registerForm.controls.name.invalid) {
+        <p class="field-error">Name must be at least 2 characters long.</p>
+      }
+
+      <label for="email">Email</label>
+      <input id="email" type="email" formControlName="email" placeholder="you@example.com" />
+      @if (registerForm.controls.email.touched && registerForm.controls.email.invalid) {
+        <p class="field-error">Enter a valid email address.</p>
+      }
+
+      <label for="password">Password</label>
+      <input id="password" type="password" formControlName="password" placeholder="Create a password" />
+      @if (registerForm.controls.password.touched && registerForm.controls.password.invalid) {
+        <p class="field-error">Password must be at least 6 characters long.</p>
+      }
+
+      <label for="confirmPassword">Confirm Password</label>
+      <input id="confirmPassword" type="password" formControlName="confirmPassword" placeholder="Re-enter your password" />
+      @if (registerForm.touched && registerForm.errors?.['passwordMismatch']) {
+        <p class="field-error">Passwords do not match.</p>
+      }
+
+      <button type="submit" [disabled]="loading">
+        {{ loading ? 'Creating account...' : 'Create account' }}
+      </button>
+    </form>
+
+    <p class="login-link">
+      Already have an account?
+      <a routerLink="/login">Sign in</a>
+    </p>
+  </section>
+</main>

--- a/webiu-ui/src/app/page/register/register.component.scss
+++ b/webiu-ui/src/app/page/register/register.component.scss
@@ -1,0 +1,102 @@
+.register-page {
+  min-height: calc(100vh - 140px);
+  display: grid;
+  place-items: center;
+  padding: 32px 20px;
+  background: radial-gradient(circle at top left, #d8f0ff 0%, transparent 44%),
+    radial-gradient(circle at bottom right, #e3fce8 0%, transparent 44%),
+    var(--cards-container);
+}
+
+.register-card {
+  width: min(100%, 500px);
+  border-radius: 14px;
+  background: var(--navbar-bg);
+  border: 1px solid var(--border-color);
+  padding: 28px;
+  box-shadow: 0 16px 38px rgba(10, 30, 54, 0.16);
+
+  h1 {
+    margin: 0;
+    color: var(--primary-dark);
+    font-size: 30px;
+  }
+
+  .subtitle {
+    margin: 10px 0 20px;
+    color: var(--font-light);
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  label {
+    font-weight: 600;
+    color: var(--primary-dark);
+    margin-top: 4px;
+  }
+
+  input {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 15px;
+    background: var(--cards-container);
+    color: var(--primary-dark);
+  }
+
+  button[type='submit'] {
+    margin-top: 8px;
+    background: #0d7bdc;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 11px 16px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.error-banner,
+.success-banner {
+  margin: 8px 0 12px;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.error-banner {
+  border: 1px solid #e89d95;
+  background: #fde8e5;
+  color: #821a15;
+}
+
+.success-banner {
+  border: 1px solid #8bcb9a;
+  background: #e7f8ec;
+  color: #16652f;
+}
+
+.field-error {
+  margin: -4px 0 2px;
+  color: #b9382b;
+  font-size: 13px;
+}
+
+.login-link {
+  margin: 18px 0 0;
+  color: var(--font-light);
+
+  a {
+    color: #0d7bdc;
+    text-decoration: none;
+    font-weight: 600;
+  }
+}

--- a/webiu-ui/src/app/page/register/register.component.ts
+++ b/webiu-ui/src/app/page/register/register.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { AuthService, RegisterResponse } from '../../services/auth.service';
+
+const passwordMatchValidator: ValidatorFn = (
+  formGroup: AbstractControl,
+): ValidationErrors | null => {
+  const password = formGroup.get('password')?.value;
+  const confirmPassword = formGroup.get('confirmPassword')?.value;
+
+  return password === confirmPassword ? null : { passwordMismatch: true };
+};
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  templateUrl: './register.component.html',
+  styleUrl: './register.component.scss',
+})
+export class RegisterComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  loading = false;
+  errorMessage = '';
+  successMessage = '';
+
+  readonly registerForm = this.fb.group(
+    {
+      name: ['', [Validators.required, Validators.minLength(2)]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(6)]],
+      confirmPassword: ['', [Validators.required]],
+    },
+    { validators: passwordMatchValidator },
+  );
+
+  submitRegister() {
+    if (this.registerForm.invalid || this.loading) {
+      this.registerForm.markAllAsTouched();
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+    this.successMessage = '';
+
+    this.authService
+      .register(this.registerForm.getRawValue() as never)
+      .subscribe({
+        next: (response: RegisterResponse) => {
+          this.successMessage =
+            response.message ||
+            'Registration successful. Please verify your email before login.';
+
+          setTimeout(() => {
+            this.router.navigate(['/login']);
+          }, 1500);
+        },
+        error: (error) => {
+          this.errorMessage =
+            error?.error?.message ||
+            'Registration failed. Please check your details and try again.';
+          this.loading = false;
+        },
+        complete: () => {
+          this.loading = false;
+        },
+      });
+  }
+}

--- a/webiu-ui/src/app/services/auth.service.ts
+++ b/webiu-ui/src/app/services/auth.service.ts
@@ -1,0 +1,212 @@
+import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, map, tap } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export type UserRole = 'admin' | 'user';
+
+export interface AuthUser {
+  id?: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  isEmailVerified?: boolean;
+}
+
+export interface AuthResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresInSeconds: number;
+  user: AuthUser;
+}
+
+export interface AuthSession {
+  accessToken: string | null;
+  tokenType: string;
+  expiresInSeconds: number;
+  user: AuthUser;
+  isOAuth?: boolean;
+}
+
+export interface RegisterResponse {
+  message: string;
+  user: AuthUser;
+  verificationToken?: string;
+}
+
+export interface AdminDashboardStat {
+  label: string;
+  value: number;
+}
+
+export interface AdminDashboardActivity {
+  type: 'issue' | 'pull-request';
+  title: string;
+  author: string;
+  url: string;
+  createdAt: string;
+  state: string;
+}
+
+export interface AdminDashboardResponse {
+  generatedAt: string;
+  stats: AdminDashboardStat[];
+  recentActivity: AdminDashboardActivity[];
+}
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly http = inject(HttpClient);
+  private readonly storageKey = 'webiu_auth_session';
+  private readonly sessionSubject = new BehaviorSubject<AuthSession | null>(
+    this.readStoredSession(),
+  );
+
+  readonly authSession$ = this.sessionSubject.asObservable();
+
+  get currentSession(): AuthSession | null {
+    return this.sessionSubject.value;
+  }
+
+  get currentUser(): AuthUser | null {
+    return this.currentSession?.user ?? null;
+  }
+
+  get accessToken(): string | null {
+    return this.currentSession?.accessToken ?? null;
+  }
+
+  get isAuthenticated(): boolean {
+    return !!this.currentSession;
+  }
+
+  get isAdmin(): boolean {
+    const session = this.currentSession;
+    return !!session?.accessToken && session.user.role === 'admin';
+  }
+
+  login(payload: LoginRequest): Observable<AuthSession> {
+    return this.http
+      .post<AuthResponse>(`${environment.serverUrl}/api/v1/auth/login`, payload)
+      .pipe(
+        map((response) => ({
+          accessToken: response.accessToken,
+          tokenType: response.tokenType,
+          expiresInSeconds: response.expiresInSeconds,
+          user: response.user,
+        })),
+        tap((session) => this.setSession(session)),
+      );
+  }
+
+  register(payload: RegisterRequest): Observable<RegisterResponse> {
+    return this.http.post<RegisterResponse>(
+      `${environment.serverUrl}/api/v1/auth/register`,
+      payload,
+    );
+  }
+
+  verifyEmail(token: string): Observable<{ message: string; user: AuthUser }> {
+    return this.http.get<{ message: string; user: AuthUser }>(
+      `${environment.serverUrl}/api/v1/auth/verify-email?token=${encodeURIComponent(token)}`,
+    );
+  }
+
+  getAdminDashboard(): Observable<AdminDashboardResponse> {
+    return this.http.get<AdminDashboardResponse>(
+      `${environment.serverUrl}/api/v1/admin/dashboard`,
+    );
+  }
+
+  setOAuthSession(user: { name?: string; email?: string }) {
+    const session: AuthSession = {
+      accessToken: null,
+      tokenType: 'Bearer',
+      expiresInSeconds: 0,
+      user: {
+        name: user.name || 'OAuth User',
+        email: user.email || 'oauth-user@webiu.local',
+        role: 'user',
+      },
+      isOAuth: true,
+    };
+
+    this.setSession(session);
+  }
+
+  consumeOAuthUserFromUrl(search: string): boolean {
+    const queryParams = new URLSearchParams(search);
+    const userParam = queryParams.get('user');
+
+    if (!userParam) {
+      return false;
+    }
+
+    try {
+      const parsedUser = JSON.parse(decodeURIComponent(userParam));
+      this.setOAuthSession(parsedUser);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  logout() {
+    this.sessionSubject.next(null);
+    this.clearStoredSession();
+  }
+
+  private setSession(session: AuthSession) {
+    this.sessionSubject.next(session);
+    this.persistSession(session);
+  }
+
+  private readStoredSession(): AuthSession | null {
+    if (!isPlatformBrowser(this.platformId)) {
+      return null;
+    }
+
+    const raw = localStorage.getItem(this.storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(raw) as AuthSession;
+    } catch {
+      return null;
+    }
+  }
+
+  private persistSession(session: AuthSession) {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    localStorage.setItem(this.storageKey, JSON.stringify(session));
+  }
+
+  private clearStoredSession() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    localStorage.removeItem(this.storageKey);
+  }
+}


### PR DESCRIPTION
Summary: add register and email verification screens wired to backend auth endpoints, wire admin dashboard to real admin API data, and add frontend integration-style tests for admin guard redirects and login-to-admin flow.\n\nValidation run: npm run build, npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/guards/admin.guard.spec.ts --include=src/app/page/login/login.component.spec.ts (in webiu-ui).\n\nDependency note: backend admin/auth API foundation is in PR #615.