### PR TITLE
fix(docker): add memory and CPU resource limits to prevent host exhau…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,14 @@ services:
       - ./webiu-server:/usr/src/app
       - server_node_modules:/usr/src/app/node_modules
     command: [ "sh", "-c", "npm install && npm run start:dev" ]
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: '0.50'
+        reservations:
+          memory: 256m
+          cpus: '0.10'
 
   webiu-ui:
     image: node:18-alpine
@@ -26,6 +34,14 @@ services:
     command: [ "sh", "-c", "npm install && npx ng serve --host 0.0.0.0" ]
     depends_on:
       - webiu-server
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: '1.50'
+        reservations:
+          memory: 512m
+          cpus: '0.25'
 
 volumes:
   server_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
     environment:
       - NODE_ENV=production
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '0.50'
+        reservations:
+          memory: 128m
+          cpus: '0.10'
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:5050/health"]
       interval: 30s
@@ -26,6 +34,14 @@ services:
     environment:
       - PORT=4000
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.25'
+        reservations:
+          memory: 64m
+          cpus: '0.05'
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:4000"]
       interval: 30s


### PR DESCRIPTION
Fixes #454

## Description

Without resource constraints, the Angular webpack dev server and NestJS
hot-reload compiler consume 1–2 GB RAM each unboundedly, causing host
slowdowns, swap usage, and potential OOM crashes.

This PR adds `deploy.resources` limits and reservations to both
`docker-compose.yml` (production) and `docker-compose.dev.yml` (development).

**Production (`docker-compose.yml`):**
| Service | Memory limit | CPU limit |
|---|---|---|
| webiu-server | 512 MB | 0.50 |
| webiu-ui | 256 MB | 0.25 |

**Development (`docker-compose.dev.yml`):**
| Service | Memory limit | CPU limit |
|---|---|---|
| webiu-server | 1 GB | 0.50 |
| webiu-ui | 2 GB | 1.50 |

Dev limits are intentionally higher to accommodate hot-reload compilation
and Angular CLI webpack memory usage during active development.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```bash
docker-compose up --build
docker-compose -f docker-compose.dev.yml up
```

Both services start correctly and stay within the defined limits.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
