### PR TITLE
Fix GitHub API error handler test compatibility

### DIFF
--- a/webiu-server/src/github/github-error.handler.ts
+++ b/webiu-server/src/github/github-error.handler.ts
@@ -1,0 +1,129 @@
+import {
+  ForbiddenException,
+  GatewayTimeoutException,
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import axios, { AxiosError } from 'axios';
+
+type GithubErrorBody = {
+  message?: string;
+  documentation_url?: string;
+};
+
+const logger = new Logger('GithubErrorHandler');
+
+function isGithubAxiosError(
+  error: unknown,
+): error is AxiosError<GithubErrorBody> {
+  return (
+    axios.isAxiosError<GithubErrorBody>(error) ||
+    (typeof error === 'object' &&
+      error !== null &&
+      (error as { isAxiosError?: boolean }).isAxiosError === true)
+  );
+}
+
+function getGithubMessage(error: unknown): string {
+  if (isGithubAxiosError(error)) {
+    return (
+      error.response?.data?.message ||
+      error.message ||
+      'GitHub API request failed'
+    );
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unknown GitHub API error';
+}
+
+export function handleGithubApiError(
+  error: unknown,
+  context = 'GitHub API request',
+): never {
+  const message = getGithubMessage(error);
+
+  if (!isGithubAxiosError(error)) {
+    logger.error(`${context} failed with unexpected error: ${message}`);
+    throw new InternalServerErrorException({
+      message: 'Unexpected GitHub API error',
+      context,
+    });
+  }
+
+  const status = error.response?.status;
+
+  logger.error(
+    `${context} failed: ${status ?? error.code ?? 'NO_STATUS'} ${message}`,
+  );
+
+  if (
+    error.code === 'ECONNABORTED' ||
+    error.message.toLowerCase().includes('timeout')
+  ) {
+    throw new GatewayTimeoutException({
+      message: 'GitHub API request timed out',
+      context,
+    });
+  }
+
+  if (!error.response) {
+    throw new ServiceUnavailableException({
+      message: 'GitHub API is currently unreachable',
+      context,
+    });
+  }
+
+  if (status === 401) {
+    throw new UnauthorizedException({
+      message: 'GitHub API authentication failed',
+      context,
+    });
+  }
+
+  if (status === 403) {
+    const isRateLimit = message.toLowerCase().includes('rate limit');
+
+    if (isRateLimit) {
+      throw new HttpException(
+        {
+          message: 'GitHub API rate limit exceeded',
+          context,
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    throw new ForbiddenException({
+      message: 'GitHub API access forbidden',
+      context,
+    });
+  }
+
+  if (status === 404) {
+    throw new NotFoundException({
+      message: 'Requested GitHub resource was not found',
+      context,
+    });
+  }
+
+  if (status && status >= 500) {
+    throw new ServiceUnavailableException({
+      message: 'GitHub API is temporarily unavailable',
+      context,
+    });
+  }
+
+  throw new InternalServerErrorException({
+    message: 'GitHub API request failed',
+    context,
+  });
+}

--- a/webiu-server/src/github/github.service.spec.ts
+++ b/webiu-server/src/github/github.service.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { GithubService } from './github.service';
 import { CacheService } from '../common/cache.service';
 import axios from 'axios';
+import { ServiceUnavailableException } from '@nestjs/common';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -73,8 +74,13 @@ describe('GithubService', () => {
     });
 
     it('should propagate errors', async () => {
-      mockedAxios.get.mockRejectedValue(new Error('API error'));
-      await expect(service.getOrgRepos()).rejects.toThrow('API error');
+      mockedAxios.get.mockRejectedValue({
+        isAxiosError: true,
+        message: 'Network Error',
+      });
+      await expect(service.getOrgRepos()).rejects.toThrow(
+        ServiceUnavailableException,
+      );
     });
   });
 
@@ -123,7 +129,10 @@ describe('GithubService', () => {
     });
 
     it('should return null on error', async () => {
-      mockedAxios.get.mockRejectedValue(new Error('API error'));
+      mockedAxios.get.mockRejectedValue({
+        isAxiosError: true,
+        message: 'Network Error',
+      });
       const result = await service.getRepoContributors('c2siorg', 'repo1');
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Description

This PR adds centralized GitHub API error handling for backend GitHub API calls.

Earlier, GitHub API failures could return raw Axios errors or generic `500 Internal Server Error` responses from different service methods. This made error behavior inconsistent across the backend.

This change introduces a reusable GitHub API error handler that maps common GitHub API failures to proper NestJS HTTP exceptions.

Fixes #628

### Motivation

GitHub API calls can fail for many expected reasons such as invalid tokens, rate limits, missing repositories, network failures, or request timeouts. These should be handled consistently instead of being converted into unclear generic server errors.

### What changed

- Added a centralized `handleGithubApiError` utility.
- Mapped GitHub API errors to consistent HTTP responses:
  - `401` → `UnauthorizedException`
  - `403` → `ForbiddenException`
  - GitHub rate limit → `429 Too Many Requests`
  - `404` → `NotFoundException`
  - Timeout → `GatewayTimeoutException`
  - Network failure → `ServiceUnavailableException`
  - Unexpected errors → `InternalServerErrorException`
- Refactored `GithubService` API calls to use the centralized handler.
- Added support for Axios-like mocked errors in tests.
- Added unit tests for GitHub API error mapping.
- Updated the existing GitHub service test to match the new error behavior.

No new external dependencies are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested the centralized GitHub API error handling with backend unit tests.

### Tests run

```bash
cd webiu-server
npm test -- github.service.spec.ts
```

This verifies that `GithubService` correctly propagates mapped GitHub API errors.

```bash
cd webiu-server
npm test
```

This verifies the existing backend test suite with the new centralized error handler.

### Test coverage added

- GitHub `401` response maps to `UnauthorizedException`.
- GitHub `403` response maps to `ForbiddenException`.
- GitHub rate limit response maps to `429 Too Many Requests`.
- GitHub `404` response maps to `NotFoundException`.
- GitHub timeout maps to `GatewayTimeoutException`.
- GitHub network failure maps to `ServiceUnavailableException`.
- Unexpected non-Axios errors map to `InternalServerErrorException`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules