### PR TITLE
feat(auth): make session cookie sameSite and secure settings configurable

### DIFF
--- a/webiu-server/.env.example
+++ b/webiu-server/.env.example
@@ -40,3 +40,8 @@ DATABASE_SSL=false
 # Cache
 CACHE_TTL_SECONDS=300
 
+# Cookie Configuration
+# COOKIE_SAMESITE can be 'lax', 'strict', or 'none'
+COOKIE_SAMESITE=lax
+# COOKIE_SECURE can be 'true' or 'false'
+COOKIE_SECURE=false

--- a/webiu-server/src/admin-profile/admin-profile.controller.ts
+++ b/webiu-server/src/admin-profile/admin-profile.controller.ts
@@ -13,6 +13,7 @@ import { AdminGuard } from '../auth/guards/admin.guard';
 import { AdminProfileService } from './admin-profile.service';
 import { UpdateUsernameDto } from './dto/update-username.dto';
 import { UpdatePasswordDto } from './dto/update-password.dto';
+import { getCookieOptions } from '../common/utils/cookie-helper';
 
 @Controller('admin/profile')
 @UseGuards(AdminGuard)
@@ -73,17 +74,6 @@ export class AdminProfileController {
   }
 
   private clearSessionCookie(request: Request, response: Response) {
-    const host = request.get('host') || '';
-    const isLocalhost =
-      host.includes('localhost') || host.includes('127.0.0.1');
-
-    response.clearCookie('admin_session', {
-      httpOnly: true,
-      secure: isLocalhost
-        ? false
-        : this.configService.get<string>('NODE_ENV') === 'production',
-      sameSite: 'lax',
-      path: '/',
-    });
+    response.clearCookie('admin_session', getCookieOptions(this.configService));
   }
 }

--- a/webiu-server/src/auth/auth.controller.ts
+++ b/webiu-server/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { Admin } from '../database/entities/admin.entity';
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { UseGuards } from '@nestjs/common';
 import { AdminGuard } from './guards/admin.guard';
+import { getCookieOptions } from '../common/utils/cookie-helper';
 
 @Controller('auth')
 export class AuthController {
@@ -38,17 +39,9 @@ export class AuthController {
     @Res({ passthrough: true }) response: Response,
   ) {
     const token = await this.authService.login(loginDto);
-    const host = request.get('host') || '';
-    const isLocalhost =
-      host.includes('localhost') || host.includes('127.0.0.1');
 
     response.cookie('admin_session', token, {
-      httpOnly: true,
-      secure: isLocalhost
-        ? false
-        : this.configService.get<string>('NODE_ENV') === 'production',
-      sameSite: 'lax',
-      path: '/',
+      ...getCookieOptions(this.configService),
       maxAge: 3600 * 1000, // 1 hour
     });
 
@@ -79,10 +72,6 @@ export class AuthController {
     @Req() request: any,
     @Res({ passthrough: true }) response: Response,
   ) {
-    const host = request.get('host') || '';
-    const isLocalhost =
-      host.includes('localhost') || host.includes('127.0.0.1');
-
     // Audit log LOGOUT
     if (request.user && request.user.id) {
       await this.auditLogService.createLog({
@@ -97,14 +86,7 @@ export class AuthController {
       });
     }
 
-    response.clearCookie('admin_session', {
-      httpOnly: true,
-      secure: isLocalhost
-        ? false
-        : this.configService.get<string>('NODE_ENV') === 'production',
-      sameSite: 'lax',
-      path: '/',
-    });
+    response.clearCookie('admin_session', getCookieOptions(this.configService));
 
     return { success: true };
   }

--- a/webiu-server/src/common/utils/cookie-helper.spec.ts
+++ b/webiu-server/src/common/utils/cookie-helper.spec.ts
@@ -1,0 +1,68 @@
+import { ConfigService } from '@nestjs/config';
+import { getCookieOptions } from './cookie-helper';
+
+describe('cookie-helper', () => {
+  let mockConfigService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    mockConfigService = {
+      get: jest.fn(),
+    } as any;
+  });
+
+  it('should return default cookie options when config variables are not set in development', () => {
+    mockConfigService.get.mockImplementation((key: string) => {
+      if (key === 'NODE_ENV') return 'development';
+      return undefined;
+    });
+
+    const options = getCookieOptions(mockConfigService);
+
+    expect(options).toEqual({
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+      path: '/',
+    });
+  });
+
+  it('should return secure: true in production environment by default', () => {
+    mockConfigService.get.mockImplementation((key: string) => {
+      if (key === 'NODE_ENV') return 'production';
+      return undefined;
+    });
+
+    const options = getCookieOptions(mockConfigService);
+
+    expect(options).toEqual({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+  });
+
+  it('should respect COOKIE_SECURE environment variable', () => {
+    mockConfigService.get.mockImplementation((key: string) => {
+      if (key === 'COOKIE_SECURE') return 'true';
+      if (key === 'NODE_ENV') return 'development';
+      return undefined;
+    });
+
+    const options = getCookieOptions(mockConfigService);
+
+    expect(options.secure).toBe(true);
+  });
+
+  it('should respect COOKIE_SAMESITE environment variable', () => {
+    mockConfigService.get.mockImplementation((key: string) => {
+      if (key === 'COOKIE_SAMESITE') return 'none';
+      if (key === 'NODE_ENV') return 'production';
+      return undefined;
+    });
+
+    const options = getCookieOptions(mockConfigService);
+
+    expect(options.sameSite).toBe('none');
+  });
+});

--- a/webiu-server/src/common/utils/cookie-helper.ts
+++ b/webiu-server/src/common/utils/cookie-helper.ts
@@ -1,0 +1,26 @@
+import { CookieOptions } from 'express';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Returns centralized cookie configuration options based on ConfigService values.
+ */
+export function getCookieOptions(configService: ConfigService): CookieOptions {
+  const secureVal = configService.get<string>('COOKIE_SECURE');
+  const sameSiteVal = configService.get<string>('COOKIE_SAMESITE');
+  const nodeEnv = configService.get<string>('NODE_ENV');
+
+  const secure =
+    secureVal !== undefined ? secureVal === 'true' : nodeEnv === 'production';
+
+  const sameSite = (sameSiteVal || 'lax').toLowerCase() as
+    | 'lax'
+    | 'strict'
+    | 'none';
+
+  return {
+    httpOnly: true,
+    secure,
+    sameSite,
+    path: '/',
+  };
+}


### PR DESCRIPTION
### Problem
In production environments where the WebiU frontend (e.g., GitHub Pages on `*.github.io`) and backend (e.g., Render on `*.onrender.com` or custom domains) reside on different registrable domains, the browser marks requests between them as **cross-site**. 

Because the `admin_session` cookie attributes were previously hardcoded to `sameSite: 'lax'` and `secure` was derived from the request host, browsers blocked the cookie from being sent on cross-site requests. As a result, admins could not maintain their session after logging in, rendering the production admin panel unusable.

Fixes #663

### Solution
1. **Centralized Cookie Options**: Created a centralized helper `getCookieOptions(configService)` in `src/common/utils/cookie-helper.ts` to generate cookie settings.
2. **Configurable Cookie Attributes**: Made attributes configurable via new environment variables:
   * `COOKIE_SAMESITE`: Can be set to `'lax'`, `'strict'`, or `'none'`. (Defaults to `'lax'`).
   * `COOKIE_SECURE`: Can be set to `'true'` or `'false'`. (Defaults to `true` in production, `false` otherwise).
3. **Refactored Controllers**: Updated `AuthController` (login/logout) and `AdminProfileController` (clear session cookie on username/password updates) to utilize the new helper.
4. **Removed Host-based Secure Derivation**: Removed the fragile host detection logic (`isLocalhost` check via `request.get('host')`) in favor of direct, predictable configuration.
5. **Added Unit Tests**: Added a spec suite for the new cookie helper.

### Verification Done
* Build passes (`npm run build`).
* Linters and formatters pass cleanly (`npm run lint` / `npm run format`).
* All unit tests pass (`npm run test`), including new unit tests for the cookie helper:
```bash
PASS src/common/utils/cookie-helper.spec.ts
  cookie-helper
    ✓ should return default cookie options when config variables are not set in development (1 ms)
    ✓ should return secure: true in production environment by default
    ✓ should respect COOKIE_SECURE environment variable (1 ms)
    ✓ should respect COOKIE_SAMESITE environment variable
