### PR TITLE
feat(auth): enforce JWT role checks and session invalidation via token versioning

### DIFF
--- a/webiu-server/src/admin-profile/admin-profile.service.ts
+++ b/webiu-server/src/admin-profile/admin-profile.service.ts
@@ -50,6 +50,7 @@ export class AdminProfileService {
     const admin = await this.getProfile(currentUsername);
     const oldUsername = admin.username;
     admin.username = trimmed;
+    admin.tokenVersion = (admin.tokenVersion || 1) + 1;
     const savedAdmin = await this.adminRepository.save(admin);
 
     if (adminId) {
@@ -97,6 +98,7 @@ export class AdminProfileService {
     }
 
     admin.passwordHash = await bcrypt.hash(newPassword, 10);
+    admin.tokenVersion = (admin.tokenVersion || 1) + 1;
     await this.adminRepository.save(admin);
 
     if (adminId) {

--- a/webiu-server/src/auth/auth.controller.spec.ts
+++ b/webiu-server/src/auth/auth.controller.spec.ts
@@ -30,11 +30,16 @@ describe('AuthController', () => {
   beforeEach(async () => {
     adminRepositoryMock = {
       findOne: jest.fn().mockImplementation(({ where }) => {
-        if (where.username === 'admin') {
-          return { id: 'mock-admin-id', username: 'admin' } as Admin;
+        if (where.username === 'admin' || where.id === 'mock-admin-id') {
+          return {
+            id: 'mock-admin-id',
+            username: 'admin',
+            tokenVersion: 1,
+          } as Admin;
         }
         return null;
       }),
+      save: jest.fn().mockResolvedValue({}),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -49,7 +54,11 @@ describe('AuthController', () => {
         {
           provide: JwtService,
           useValue: {
-            verify: jest.fn().mockReturnValue({ username: 'admin' }),
+            verify: jest.fn().mockReturnValue({
+              username: 'admin',
+              role: 'admin',
+              tokenVersion: 1,
+            }),
           },
         },
         {

--- a/webiu-server/src/auth/auth.controller.ts
+++ b/webiu-server/src/auth/auth.controller.ts
@@ -72,8 +72,17 @@ export class AuthController {
     @Req() request: any,
     @Res({ passthrough: true }) response: Response,
   ) {
-    // Audit log LOGOUT
+    // Invalidate token by incrementing version in database
     if (request.user && request.user.id) {
+      const admin = await this.adminRepository.findOne({
+        where: { id: request.user.id },
+      });
+      if (admin) {
+        admin.tokenVersion = (admin.tokenVersion || 1) + 1;
+        await this.adminRepository.save(admin);
+      }
+
+      // Audit log LOGOUT
       await this.auditLogService.createLog({
         adminId: request.user.id,
         action: 'LOGOUT',
@@ -106,7 +115,11 @@ export class AuthController {
         where: { username: decoded.username },
       });
 
-      if (adminExists) {
+      if (
+        adminExists &&
+        decoded.role === 'admin' &&
+        decoded.tokenVersion === adminExists.tokenVersion
+      ) {
         return { authenticated: true };
       }
     } catch {}

--- a/webiu-server/src/auth/auth.service.spec.ts
+++ b/webiu-server/src/auth/auth.service.spec.ts
@@ -1,16 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CredentialService } from './credential.service';
 import { LoginDto } from './dto/login.dto';
+import { Admin } from '../database/entities/admin.entity';
 
 describe('AuthService', () => {
   let service: AuthService;
   let credentialService: CredentialService;
   let jwtService: JwtService;
+  let adminRepositoryMock: any;
 
   beforeEach(async () => {
+    adminRepositoryMock = {
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
@@ -25,6 +32,10 @@ describe('AuthService', () => {
           useValue: {
             sign: jest.fn().mockReturnValue('mock-jwt-token'),
           },
+        },
+        {
+          provide: getRepositoryToken(Admin),
+          useValue: adminRepositoryMock,
         },
       ],
     }).compile();
@@ -47,6 +58,10 @@ describe('AuthService', () => {
       (credentialService.validateCredentials as jest.Mock).mockResolvedValue(
         true,
       );
+      adminRepositoryMock.findOne.mockResolvedValue({
+        username: 'admin',
+        tokenVersion: 1,
+      } as Admin);
 
       const result = await service.login(loginDto);
 
@@ -58,6 +73,7 @@ describe('AuthService', () => {
       expect(jwtService.sign).toHaveBeenCalledWith({
         username: 'admin',
         role: 'admin',
+        tokenVersion: 1,
       });
     });
 

--- a/webiu-server/src/auth/auth.service.ts
+++ b/webiu-server/src/auth/auth.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Admin } from '../database/entities/admin.entity';
 import { CredentialService } from './credential.service';
 import { LoginDto } from './dto/login.dto';
 
@@ -8,6 +11,8 @@ export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly credentialService: CredentialService,
+    @InjectRepository(Admin)
+    private readonly adminRepository: Repository<Admin>,
   ) {}
 
   async login(loginDto: LoginDto): Promise<string> {
@@ -20,7 +25,15 @@ export class AuthService {
       throw new UnauthorizedException('Invalid administrator credentials');
     }
 
-    const payload = { username: loginDto.username, role: 'admin' };
+    const admin = await this.adminRepository.findOne({
+      where: { username: loginDto.username },
+    });
+
+    const payload = {
+      username: loginDto.username,
+      role: 'admin',
+      tokenVersion: admin ? admin.tokenVersion : 1,
+    };
     return this.jwtService.sign(payload);
   }
 }

--- a/webiu-server/src/auth/guards/admin.guard.spec.ts
+++ b/webiu-server/src/auth/guards/admin.guard.spec.ts
@@ -27,7 +27,7 @@ describe('AdminGuard', () => {
     adminRepositoryMock = {
       findOne: jest.fn().mockImplementation(({ where }) => {
         if (where.username === 'admin') {
-          return { username: 'admin' } as Admin;
+          return { username: 'admin', tokenVersion: 1 } as Admin;
         }
         return null;
       }),
@@ -39,7 +39,11 @@ describe('AdminGuard', () => {
         {
           provide: JwtService,
           useValue: {
-            verify: jest.fn().mockReturnValue({ username: 'admin' }),
+            verify: jest.fn().mockReturnValue({
+              username: 'admin',
+              role: 'admin',
+              tokenVersion: 1,
+            }),
           },
         },
         {
@@ -58,7 +62,7 @@ describe('AdminGuard', () => {
   });
 
   describe('canActivate', () => {
-    it('should return true if token is valid and matches admin username in db', async () => {
+    it('should return true if token is valid and matches admin username, role, and version in db', async () => {
       const context = mockExecutionContext('valid-jwt-token');
 
       const result = await guard.canActivate(context);
@@ -93,6 +97,34 @@ describe('AdminGuard', () => {
       const context = mockExecutionContext('valid-jwt-token');
       (jwtService.verify as jest.Mock).mockReturnValue({
         username: 'not-admin',
+        role: 'admin',
+        tokenVersion: 1,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException if role in JWT is not admin', async () => {
+      const context = mockExecutionContext('valid-jwt-token');
+      (jwtService.verify as jest.Mock).mockReturnValue({
+        username: 'admin',
+        role: 'user',
+        tokenVersion: 1,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException if tokenVersion in JWT does not match db version', async () => {
+      const context = mockExecutionContext('valid-jwt-token');
+      (jwtService.verify as jest.Mock).mockReturnValue({
+        username: 'admin',
+        role: 'admin',
+        tokenVersion: 2, // mismatch
       });
 
       await expect(guard.canActivate(context)).rejects.toThrow(

--- a/webiu-server/src/auth/guards/admin.guard.ts
+++ b/webiu-server/src/auth/guards/admin.guard.ts
@@ -37,13 +37,26 @@ export class AdminGuard implements CanActivate {
         throw new UnauthorizedException('Not authorized as administrator');
       }
 
+      if (decoded.role !== 'admin') {
+        throw new UnauthorizedException('Not authorized as administrator');
+      }
+
+      if (decoded.tokenVersion !== adminExists.tokenVersion) {
+        throw new UnauthorizedException(
+          'Authentication session is invalid or expired',
+        );
+      }
+
       request.user = {
         id: adminExists.id,
         username: adminExists.username,
         role: decoded.role,
       };
       return true;
-    } catch {
+    } catch (err) {
+      if (err instanceof UnauthorizedException) {
+        throw err;
+      }
       throw new UnauthorizedException(
         'Authentication session is invalid or expired',
       );

--- a/webiu-server/src/database/entities/admin.entity.ts
+++ b/webiu-server/src/database/entities/admin.entity.ts
@@ -25,4 +25,7 @@ export class Admin {
 
   @Column({ nullable: true, type: 'timestamp' })
   lastLoginAt: Date;
+
+  @Column({ default: 1 })
+  tokenVersion: number;
 }

--- a/webiu-server/src/database/migrations/1781833000000-AddTokenVersionToAdmins.ts
+++ b/webiu-server/src/database/migrations/1781833000000-AddTokenVersionToAdmins.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTokenVersionToAdmins1781833000000 implements MigrationInterface {
+  name = 'AddTokenVersionToAdmins1781833000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "admins" ADD "tokenVersion" integer NOT NULL DEFAULT 1`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "admins" DROP COLUMN "tokenVersion"`);
+  }
+}


### PR DESCRIPTION
### Problem
Previously, WebiU's stateless JWT authentication had two significant security gaps:
1. **Lack of Token Invalidation**: When an admin logged out or updated their username/password, only the browser-side cookie was cleared. The JWT token remained valid until its natural 1-hour expiration. An attacker who had hijacked the token could access administrative endpoints `/admin/*` in that duration.
2. **Missing Role Enforcement**: `AdminGuard` verified that the JWT signature was correct and that the admin user existed, but did not enforce the `decoded.role === 'admin'` check.

Resolves #664.

### Solution
1. **Added Token Versioning**: Created a migration adding a `tokenVersion` column to the `admins` table.
2. **Active Version Invalidation**:
   * Incremented `tokenVersion` in the DB when credentials (password/username) are updated in `AdminProfileService`.
   * Incremented `tokenVersion` in the DB upon logging out in `AuthController`.
3. **Payload Verification**:
   * Injected the admin repository in `AuthService` and appended the current `tokenVersion` to the JWT payload during login.
4. **Validation Enforcements**:
   * Updated `AdminGuard` to throw `UnauthorizedException` if `decoded.role !== 'admin'` or if `decoded.tokenVersion !== admin.tokenVersion`.
   * Applied matching enforcements in the `/auth/me` (`checkSession`) controller method.
5. **Tests**: Updated all existing guard/auth test suites and added assertions for mismatch/role violations.

### Verification Done
* Build passes (`npm run build`).
* Linters and formatters pass cleanly (`npm run lint` / `npm run format`).
* All unit tests pass (`npm run test`):
```bash
PASS src/auth/guards/admin.guard.spec.ts
  AdminGuard
    ✓ should return true if token is valid and matches admin username, role, and version in db (1 ms)
    ✓ should throw UnauthorizedException if cookie is missing
    ✓ should throw UnauthorizedException if jwt validation fails (1 ms)
    ✓ should throw UnauthorizedException if username in JWT does not exist in db
    ✓ should throw UnauthorizedException if role in JWT is not admin
    ✓ should throw UnauthorizedException if tokenVersion in JWT does not match db version
