### PR TITLE
fix(server): implement backend enforcement for maintenance mode

### DIFF
--- a/webiu-server/src/app.module.ts
+++ b/webiu-server/src/app.module.ts
@@ -4,6 +4,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { GqlThrottlerGuard } from './graphql/gql-throttler.guard';
+import { MaintenanceGuard } from './auth/guards/maintenance.guard';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import * as depthLimit from 'graphql-depth-limit';
@@ -66,6 +67,11 @@ import { AuditLogModule } from './audit-log/audit-log.module';
     {
       provide: APP_GUARD,
       useClass: GqlThrottlerGuard,
+    },
+    // Enforce Maintenance Mode globally — intercepts HTTP and GraphQL contexts
+    {
+      provide: APP_GUARD,
+      useClass: MaintenanceGuard,
     },
   ],
 })

--- a/webiu-server/src/auth/guards/maintenance.guard.spec.ts
+++ b/webiu-server/src/auth/guards/maintenance.guard.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ServiceUnavailableException, ExecutionContext } from '@nestjs/common';
+import { MaintenanceGuard } from './maintenance.guard';
+import { Admin } from '../../database/entities/admin.entity';
+import { SystemSettingService } from '../../system-setting/system-setting.service';
+
+describe('MaintenanceGuard', () => {
+  let guard: MaintenanceGuard;
+  let systemSettingService: SystemSettingService;
+  let jwtService: JwtService;
+  let adminRepositoryMock: any;
+
+  const mockExecutionContext = (
+    path: string,
+    cookieValue?: string,
+    type: 'http' | 'graphql' = 'http',
+  ): ExecutionContext => {
+    const request = {
+      path,
+      url: path,
+      headers: {
+        cookie: cookieValue ? `admin_session=${cookieValue}` : undefined,
+      },
+    } as any;
+
+    if (type === 'http') {
+      return {
+        getType: () => 'http',
+        switchToHttp: () => ({
+          getRequest: () => request,
+        }),
+      } as any;
+    } else {
+      return {
+        getType: () => 'graphql',
+        getHandler: () => ({}),
+        getClass: () => ({}),
+        getArgs: () => [{}, {}, { req: request }, {}],
+      } as any;
+    }
+  };
+
+  beforeEach(async () => {
+    adminRepositoryMock = {
+      findOne: jest.fn().mockImplementation(({ where }) => {
+        if (where.username === 'admin') {
+          return { username: 'admin', tokenVersion: 1 } as Admin;
+        }
+        return null;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MaintenanceGuard,
+        {
+          provide: SystemSettingService,
+          useValue: {
+            getSettingBool: jest.fn().mockResolvedValue(false),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            verify: jest.fn().mockReturnValue({
+              username: 'admin',
+              role: 'admin',
+              tokenVersion: 1,
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(Admin),
+          useValue: adminRepositoryMock,
+        },
+      ],
+    }).compile();
+
+    guard = module.get<MaintenanceGuard>(MaintenanceGuard);
+    systemSettingService =
+      module.get<SystemSettingService>(SystemSettingService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    it('should return true if maintenance mode is disabled', async () => {
+      jest
+        .spyOn(systemSettingService, 'getSettingBool')
+        .mockResolvedValue(false);
+      const context = mockExecutionContext('/api/v1/projects');
+
+      const result = await guard.canActivate(context);
+      expect(result).toBe(true);
+    });
+
+    describe('when maintenance mode is enabled', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(systemSettingService, 'getSettingBool')
+          .mockResolvedValue(true);
+      });
+
+      it('should allow /health check', async () => {
+        const context = mockExecutionContext('/health');
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+      });
+
+      it('should allow /ready check', async () => {
+        const context = mockExecutionContext('/ready');
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+      });
+
+      it('should allow admin routes starting with /admin', async () => {
+        const context = mockExecutionContext('/admin/settings');
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+      });
+
+      it('should allow auth routes starting with /auth', async () => {
+        const context = mockExecutionContext('/auth/login');
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+      });
+
+      it('should block public routes for unauthenticated users', async () => {
+        const context = mockExecutionContext('/api/v1/projects');
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          ServiceUnavailableException,
+        );
+      });
+
+      it('should allow public routes for authenticated admins', async () => {
+        const context = mockExecutionContext('/api/v1/projects', 'valid-jwt');
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+        expect(jwtService.verify).toHaveBeenCalledWith('valid-jwt');
+      });
+
+      it('should block public routes if admin cookie verification fails', async () => {
+        const context = mockExecutionContext('/api/v1/projects', 'invalid-jwt');
+        jest.spyOn(jwtService, 'verify').mockImplementation(() => {
+          throw new Error('invalid token');
+        });
+
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          ServiceUnavailableException,
+        );
+      });
+
+      it('should work for GraphQL context (block when no admin)', async () => {
+        const context = mockExecutionContext('/graphql', undefined, 'graphql');
+        await expect(guard.canActivate(context)).rejects.toThrow(
+          ServiceUnavailableException,
+        );
+      });
+
+      it('should work for GraphQL context (allow when admin present)', async () => {
+        const context = mockExecutionContext(
+          '/graphql',
+          'valid-jwt',
+          'graphql',
+        );
+        const result = await guard.canActivate(context);
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/webiu-server/src/auth/guards/maintenance.guard.ts
+++ b/webiu-server/src/auth/guards/maintenance.guard.ts
@@ -1,0 +1,94 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Admin } from '../../database/entities/admin.entity';
+import { SystemSettingService } from '../../system-setting/system-setting.service';
+
+@Injectable()
+export class MaintenanceGuard implements CanActivate {
+  constructor(
+    private readonly systemSettingService: SystemSettingService,
+    private readonly jwtService: JwtService,
+    @InjectRepository(Admin)
+    private readonly adminRepository: Repository<Admin>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isMaintenance = await this.systemSettingService.getSettingBool(
+      'site.maintenance_mode',
+    );
+    if (!isMaintenance) {
+      return true;
+    }
+
+    let req: any;
+    if (context.getType() === 'http') {
+      req = context.switchToHttp().getRequest();
+    } else {
+      const gqlCtx = GqlExecutionContext.create(context);
+      req = gqlCtx.getContext().req;
+    }
+
+    if (!req) {
+      return true;
+    }
+
+    const cleanPath = (req.path || req.url || '').split('?')[0];
+    if (
+      cleanPath === '/health' ||
+      cleanPath === '/ready' ||
+      cleanPath.startsWith('/admin') ||
+      cleanPath.startsWith('/auth')
+    ) {
+      return true;
+    }
+
+    // Check if the request is from an authenticated admin
+    const cookieHeader = req.headers?.cookie;
+    const token = this.extractCookie(cookieHeader, 'admin_session');
+    if (token) {
+      try {
+        const decoded = this.jwtService.verify(token);
+        const adminExists = await this.adminRepository.findOne({
+          where: { username: decoded.username },
+        });
+
+        if (
+          adminExists &&
+          decoded.role === 'admin' &&
+          decoded.tokenVersion === adminExists.tokenVersion
+        ) {
+          return true;
+        }
+      } catch {
+        // Not a valid admin token, fall through to block
+      }
+    }
+
+    throw new ServiceUnavailableException(
+      'Site is currently undergoing maintenance. Please try again later.',
+    );
+  }
+
+  private extractCookie(
+    cookieHeader: string | undefined,
+    name: string,
+  ): string | null {
+    if (!cookieHeader) return null;
+    const cookies = cookieHeader.split(';').map((c) => c.trim());
+    for (const cookie of cookies) {
+      const [key, ...valueParts] = cookie.split('=');
+      if (key === name) {
+        return valueParts.join('=');
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
### Problem Description
Previously, `site.maintenance_mode` was purely cosmetic-toggling only a frontend UI overlay. The backend server continued to serve all public REST endpoints (`/api/*`, `/gsoc/*`) and GraphQL queries, leaving the application unprotected during deployments and migrations.

Fixes #668 

### Solutions & Design Decisions
- **`MaintenanceGuard` Implementation**: Created a new NestJS guard (`MaintenanceGuard`) to enforce maintenance mode on the backend.
  - Automatically permits health checks (`/health`, `/ready`) to pass so load-balancers don't evict the server instance.
  - Permits admin (`/admin/*`) and authentication (`/auth/*`) endpoints to remain reachable so admins can authenticate and turn off maintenance mode.
  - Inspects the `admin_session` cookie; requests containing valid administrator session signatures bypass maintenance mode.
  - Denies all other requests (HTTP & GraphQL) with a `503 Service Unavailable` exception.
- **Global Application**: Registered the guard as a global `APP_GUARD` in `AppModule`.

### Verification
- Implemented unit tests in `maintenance.guard.spec.ts` testing HTTP, GraphQL, bypassed routes, and admin validation checks.
- Verified that `npm run build`, `npm run lint`, and `npm test` all execute and pass perfectly (199/199 tests passing).
