### PR TITLE
fix(user): add error handling to UserService

### DIFF
--- a/webiu-server/src/user/user.service.spec.ts
+++ b/webiu-server/src/user/user.service.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
 import { GithubService } from '../github/github.service';
+import { InternalServerErrorException, Logger } from '@nestjs/common';
 
 describe('UserService', () => {
   let service: UserService;
-
+  let loggerErrorSpy: jest.SpyInstance;
   const mockGithubService = {
     getPublicUserProfile: jest.fn(),
     getUserFollowersAndFollowing: jest.fn(),
@@ -19,9 +20,64 @@ describe('UserService', () => {
     }).compile();
 
     service = module.get<UserService>(UserService);
+    loggerErrorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getFollowersAndFollowing', () => {
+    it('should return followers and following on success', async () => {
+      mockGithubService.getUserFollowersAndFollowing.mockResolvedValue({
+        followers: 100,
+        following: 50,
+      });
+      const result = await service.getFollowersAndFollowing('testuser');
+      expect(result).toEqual({ followers: 100, following: 50 });
+    });
+
+    it('should throw InternalServerErrorException and log on failure', async () => {
+      const error = new Error('GitHub API error');
+      mockGithubService.getUserFollowersAndFollowing.mockRejectedValue(error);
+
+      await expect(
+        service.getFollowersAndFollowing('testuser'),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Error fetching followers and following:',
+        'GitHub API error',
+      );
+    });
+  });
+
+  describe('getUserProfile', () => {
+    it('should return user profile on success', async () => {
+      const profile = { login: 'testuser', avatar_url: 'url' };
+      mockGithubService.getPublicUserProfile.mockResolvedValue(profile);
+      const result = await service.getUserProfile('testuser');
+      expect(result).toEqual(profile);
+    });
+
+    it('should throw InternalServerErrorException and log on failure', async () => {
+      const error = new Error('GitHub API error');
+      mockGithubService.getPublicUserProfile.mockRejectedValue(error);
+
+      await expect(service.getUserProfile('testuser')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Error fetching user profile:',
+        'GitHub API error',
+      );
+    });
   });
 });

--- a/webiu-server/src/user/user.service.ts
+++ b/webiu-server/src/user/user.service.ts
@@ -1,12 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { GithubService } from '../github/github.service';
 
 @Injectable()
 export class UserService {
+  private readonly logger = new Logger(UserService.name);
+
   constructor(private githubService: GithubService) {}
 
   async getFollowersAndFollowing(username: string) {
-    return this.githubService.getUserFollowersAndFollowing(username);
+    try {
+      return await this.githubService.getUserFollowersAndFollowing(username);
+    } catch (error) {
+      this.logger.error(
+        'Error fetching followers and following:',
+        error.response ? error.response.data : error.message,
+      );
+      throw new InternalServerErrorException('Internal server error');
+    }
   }
 
   async batchFollowersAndFollowing(
@@ -37,6 +51,14 @@ export class UserService {
   }
 
   async getUserProfile(username: string) {
-    return this.githubService.getPublicUserProfile(username);
+    try {
+      return await this.githubService.getPublicUserProfile(username);
+    } catch (error) {
+      this.logger.error(
+        'Error fetching user profile:',
+        error.response ? error.response.data : error.message,
+      );
+      throw new InternalServerErrorException('Failed to fetch user profile');
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR adds missing error handling to UserService, resolving an inconsistency where it was the only core service lacking proper try/catch blocks. It follows the exact pattern established in ContributorService (`contributor.service.ts:89-107`) and ProjectService (`project.service.ts:65-71`).

## Related Issue

Resolves #628

## Motivation and Context

Currently, if the GitHub API fails during `getUserProfile` or `getFollowersAndFollowing`, the raw Axios error propagates unhandled. This bypasses NestJS's typed exception layer and fails to write contextual server-side logs, making debugging extremely difficult.

Previous attempt #629 proposed a centralized error handler but was closed due to complexity and 403 ambiguity. As requested in issue #268, this is a focused, single-concern PR utilizing the existing, maintainer-approved per-service pattern.

## Changes Made

1. **webiu-server/src/user/user.service.ts**
   - Added `Logger` and `InternalServerErrorException` imports.
   - Added `private readonly logger = new Logger(UserService.name)`.
   - Wrapped `getFollowersAndFollowing` in try/catch (throws generic `Internal server error` to avoid duplicate logging with `github.service.ts`).
   - Wrapped `getUserProfile` in try/catch (throws specific `Failed to fetch user profile` because the underlying `github.service.ts` method has no logging).
   - `batchFollowersAndFollowing` was left untouched as `Promise.allSettled` inherently handles individual failures.

2. **webiu-server/src/user/user.service.spec.ts**
   - Expanded from 1 basic test to 5 comprehensive tests.
   - Added success path tests for both methods.
   - Added failure path tests verifying that `InternalServerErrorException` is thrown AND `Logger.prototype.error` is called with the correct contextual message using `jest.spyOn`.

## How Has This Been Tested?

- [x] `npm run lint` (Passes)
- [x] `npm run build` (Passes)
- [x] `npm test -- user.service.spec` (All 5 tests passing)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change does not require a change to the documentation.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have signed my commits (DCO).