### PR TITLE
fix(server): replace generic Error with InternalServerErrorException across email and GitHub services

### DIFF
--- a/webiu-server/src/email/email.service.ts
+++ b/webiu-server/src/email/email.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import { getVerifyEmailTemplate } from './templates/verify-email.template';
@@ -39,7 +43,9 @@ export class EmailService {
       this.logger.log(`Verification email sent to ${email}`);
     } catch (error) {
       this.logger.error('Error sending email:', error);
-      throw new Error('Failed to send verification email');
+      throw new InternalServerErrorException(
+        'Failed to send verification email',
+      );
     }
   }
 }

--- a/webiu-server/src/github/github.graphql.service.ts
+++ b/webiu-server/src/github/github.graphql.service.ts
@@ -79,7 +79,9 @@ export class GithubGraphqlService {
       );
 
       if (!response.data?.data) {
-        throw new Error('Invalid response from GitHub API');
+        throw new InternalServerErrorException(
+          'Invalid response from GitHub API',
+        );
       }
 
       const prs = response.data.data.search.nodes;

--- a/webiu-server/src/github/github.service.ts
+++ b/webiu-server/src/github/github.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../common/cache.service';
 import axios, { AxiosError } from 'axios';
@@ -123,7 +127,7 @@ export class GithubService {
       }
     }
 
-    throw new Error(
+    throw new InternalServerErrorException(
       `GitHub request to ${url} failed after ${maxRetries} attempts`,
     );
   }


### PR DESCRIPTION
## Description

While reviewing the backend services, I noticed a small inconsistency in how errors are handled. A few places throw plain JavaScript new Error(...) instead of NestJS's HttpException subclasses.

I realized that NestJS's built-in global exception filter doesn't recognize generic Error objects. When this happens, the filter ignores the custom error message and just returns a generic 500: Internal server error to the client. To keep error responses consistent with the rest of the codebase (like in project.service.ts and user.service.ts), I updated these to use InternalServerErrorException.

**Changes made:**

- **email/email.service.ts**: Updated the catch block to throw InternalServerErrorException. Previously, the custom message was lost. (Note: I saw that EmailModule isn't currently wired into AppModule, but I thought it was best to fix this anyway so it's correct whenever it gets hooked up).

- **github/github.service.ts**: Updated the fallthrough error in getWithRetry(). I left the throw error on line 122 untouched, as upstream callers rely on that specific AxiosError shape for cache fallback logic.

- **github/github.graphql.service.ts**: Updated the invalid response check to throw InternalServerErrorException directly instead of a generic Error.

This is just a minor cleanup to help keep the error handling pattern uniform across the project. Let me know if anything needs to be adjusted!

Fixes # (none — codebase cleanup)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Ran npm run lint in webiu-server (passes)
- [x] Ran npm run build in webiu-server (passes)
- [x] Ran npm test in webiu-server (passes)
- [x] Manual code review to ensure InternalServerErrorException (which extends Error) doesn't break any existing catch blocks or instanceof checks.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR description accurately matches the actual code changes and file diffs
- [ ] Any dependent changes have been merged and published in downstream modules