### PR TITLE
fix(graphql): add followers and following fields to Contributor model

### DIFF
--- a/webiu-server/src/graphql/models/contributor.model.ts
+++ b/webiu-server/src/graphql/models/contributor.model.ts
@@ -13,4 +13,10 @@ export class Contributor {
 
   @Field(() => [String])
   repos: string[];
+
+  @Field(() => Int, { nullable: true })
+  followers?: number;
+
+  @Field(() => Int, { nullable: true })
+  following?: number;
 }


### PR DESCRIPTION
Fixes #693

## Description

Adds `followers` and `following` fields to the GraphQL `Contributor` model as nullable integers (`Int`).

This aligns the GraphQL schema with the frontend `Contributor` interface (`webiu-ui/src/app/common/data/contributor.ts`). Currently, the frontend enriches contributor data with social stats via a separate REST endpoint (`POST /api/user/batch-social`). The REST API and GraphQL resolver do not currently return these fields.

Adding them as **nullable** fields safely updates the schema without causing `"Cannot return null for non-nullable field"` runtime errors. This PR serves as the foundational schema update; a follow-up can update the GraphQL resolver to populate these fields via `GithubService`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `npm run lint` and `npm test` successfully (no failures).
- Started the local GraphQL server and executed:

```graphql
query {
  contributors(page: 1, limit: 5) {
    login
    followers
    following
  }
}
```

- Verified the query executes successfully, returning `null` for `followers` and `following` (since the resolver does not populate them yet). No GraphQL schema errors.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules