### PR TITLE
fix(ui): correct getProfileUrl to return GitHub profile URL instead of PR search URL

### DIFF
--- a/webiu-ui/src/app/components/project-contributors/project-contributors.component.ts
+++ b/webiu-ui/src/app/components/project-contributors/project-contributors.component.ts
@@ -71,7 +71,7 @@ export class ProjectContributorsComponent implements OnInit {
   }
 
   getProfileUrl(username: string): string {
-    return `${this.repoBase}/pulls?q=author%3A${encodeURIComponent(username)}`;
+    return `https://github.com/${username}`;
   }
 
   toggleView(): void {


### PR DESCRIPTION
Fixes #696

## Description
ProjectContributorsComponent.getProfileUrl() was returning a PR search URL
(https://github.com/c2siorg/{repo}/pulls?q=author:{username}) instead of the
user's actual GitHub profile (https://github.com/{username}). This was a
copy-paste error from getOpenPrsUrl introduced in commit 7827ccf.

The fix changes line 74 to return the standard GitHub profile URL format,
matching the pattern already used in profile-card.component.html:37.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [X] npm run lint — passes
- [X] npm run build — compiles with 0 errors
- [X] npm test — all tests pass (61/61)
- [X] Manual verification: Clicked contributor avatar on local environment
      and verified it redirects to https://github.com/{username}

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes