### PR TITLE
fix(directives): kill GSAP tweens on ngOnDestroy to prevent memory leaks

### DIFF
--- a/webiu-ui/src/app/shared/count-up.directive.ts
+++ b/webiu-ui/src/app/shared/count-up.directive.ts
@@ -14,6 +14,7 @@ export class CountUpDirective implements OnInit, OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private ngZone = inject(NgZone);
   private observer?: IntersectionObserver;
+  private tween?: gsap.core.Tween;
 
   ngOnInit(): void {
     if (!isPlatformBrowser(this.platformId)) return;
@@ -48,7 +49,7 @@ export class CountUpDirective implements OnInit, OnDestroy {
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
               const counter = { val: 0 };
-              gsap.to(counter, {
+              this.tween = gsap.to(counter, {
                 val: numericVal,
                 duration: this.duration,
                 ease: 'power2.out',
@@ -74,6 +75,7 @@ export class CountUpDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.tween?.kill();
     if (this.observer) {
       this.observer.disconnect();
     }

--- a/webiu-ui/src/app/shared/reveal-on-scroll.directive.ts
+++ b/webiu-ui/src/app/shared/reveal-on-scroll.directive.ts
@@ -15,6 +15,7 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private ngZone = inject(NgZone);
   private observer?: IntersectionObserver;
+  private tween?: gsap.core.Tween;
 
   ngOnInit(): void {
     if (!isPlatformBrowser(this.platformId)) return;
@@ -54,7 +55,7 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
         (entries) => {
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
-              gsap.to(nativeEl, {
+              this.tween = gsap.to(nativeEl, {
                 opacity: 1,
                 scale: 1,
                 x: 0,
@@ -79,6 +80,7 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.tween?.kill();
     if (this.observer) {
       this.observer.disconnect();
     }


### PR DESCRIPTION
## Description

This PR fixes a memory leak in count-up.directive.ts and reveal-on-scroll.directive.ts. Previously, the gsap.to() return values (tweens) were discarded, meaning they could not be cleaned up. If a user navigated away from the page mid-animation, the tween would continue running on the detached DOM node.

This PR stores the tween reference in a private variable and calls this.tween?.kill() inside ngOnDestroy() to properly clean up the animation and prevent memory leaks. This aligns with the existing cleanup patterns already established in ParallaxDirective (parallax.directive.ts:76-83).

Fixes #700

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran `npm run lint` inside webiu-ui/ — 0 errors, 0 warnings
- Ran `npm run build` inside webiu-ui/ — compiled successfully (0 errors)
- Ran `npm test` inside webiu-ui/ — all 61 existing unit tests pass (SUCCESS)
- Manually verified: triggered count-up and reveal-on-scroll animations, navigated mid-animation, confirmed no GSAP warnings in console and tween is terminated on destroy

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] My PR description accurately matches the actual code changes and file diffs
- [ ] Any dependent changes have been merged and published in downstream modules