### PR TITLE
fix: resolve memory leaks and subscription leaks in search, admin dashboard, and animation directives

### DIFF
--- a/webiu-ui/src/app/components/spotlight-search/spotlight-search.component.ts
+++ b/webiu-ui/src/app/components/spotlight-search/spotlight-search.component.ts
@@ -3,18 +3,19 @@ import {
   ElementRef,
   HostListener,
   OnInit,
-  OnDestroy,
   ViewChild,
   inject,
   PLATFORM_ID,
+  DestroyRef,
 } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ProjectCacheService } from '../../services/project-cache.service';
 import { Project } from '../../page/projects/project.model';
 import { SearchService } from '../../services/search.service';
 import { getLanguageColor } from '../../common/utils/language-colors';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 
 @Component({
@@ -245,7 +246,7 @@ import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
     `,
   ],
 })
-export class SpotlightSearchComponent implements OnInit, OnDestroy {
+export class SpotlightSearchComponent implements OnInit {
   @ViewChild('searchInput') searchInputRef!: ElementRef<HTMLInputElement>;
 
   isOpen = false;
@@ -253,29 +254,30 @@ export class SpotlightSearchComponent implements OnInit, OnDestroy {
   results: Project[] = [];
   selectedIndex = 0;
   private searchSubject = new Subject<string>();
-  private searchSubscription?: Subscription;
-  private toggleSubscription?: Subscription;
   private isBrowser: boolean;
 
   private projectService = inject(ProjectCacheService);
   private searchService = inject(SearchService);
   private router = inject(Router);
   private platformId = inject(PLATFORM_ID);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {
     this.isBrowser = isPlatformBrowser(this.platformId);
   }
 
   ngOnInit(): void {
-    this.toggleSubscription = this.searchService.isOpen$.subscribe((open) => {
-      if (open) {
-        this.openSearch();
-      } else {
-        this.closeSearch();
-      }
-    });
+    this.searchService.isOpen$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((open) => {
+        if (open) {
+          this.openSearch();
+        } else {
+          this.closeSearch();
+        }
+      });
 
-    this.searchSubscription = this.searchSubject
+    this.searchSubject
       .pipe(
         debounceTime(200),
         distinctUntilChanged(),
@@ -284,21 +286,13 @@ export class SpotlightSearchComponent implements OnInit, OnDestroy {
             return [ { repositories: [], total: 0 } ];
           }
           return this.projectService.searchProjects(q, 1, 6);
-        })
+        }),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((res) => {
         this.results = res.repositories || [];
         this.selectedIndex = 0;
       });
-  }
-
-  ngOnDestroy(): void {
-    if (this.searchSubscription) {
-      this.searchSubscription.unsubscribe();
-    }
-    if (this.toggleSubscription) {
-      this.toggleSubscription.unsubscribe();
-    }
   }
 
   @HostListener('document:keydown', ['$event'])

--- a/webiu-ui/src/app/page/admin-ideas/admin-ideas.component.ts
+++ b/webiu-ui/src/app/page/admin-ideas/admin-ideas.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink, RouterLinkActive, ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GsocService, GsocProgram, GsocIdea, GsocMentor } from '../../services/gsoc.service';
 import { AuthService } from '../../services/auth.service';
 import { ThemeService } from '../../services/theme.service';
@@ -21,6 +22,7 @@ export class AdminIdeasComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private toastr = inject(ToastrService);
+  private destroyRef = inject(DestroyRef);
 
   // UI state
   activeTab: 'programs' | 'ideas' | 'mentors' = 'programs';
@@ -80,15 +82,17 @@ export class AdminIdeasComponent implements OnInit {
     this.isSunVisible = !this.themeService.isDarkMode();
     
     // Listen to query parameters to change tab dynamically
-    this.route.queryParams.subscribe((params) => {
-      if (params['tab'] === 'ideas') {
-        this.activeTab = 'ideas';
-      } else if (params['tab'] === 'mentors') {
-        this.activeTab = 'mentors';
-      } else {
-        this.activeTab = 'programs';
-      }
-    });
+    this.route.queryParams
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((params) => {
+        if (params['tab'] === 'ideas') {
+          this.activeTab = 'ideas';
+        } else if (params['tab'] === 'mentors') {
+          this.activeTab = 'mentors';
+        } else {
+          this.activeTab = 'programs';
+        }
+      });
 
     this.loadAllData();
   }

--- a/webiu-ui/src/app/shared/count-up.directive.ts
+++ b/webiu-ui/src/app/shared/count-up.directive.ts
@@ -14,6 +14,7 @@ export class CountUpDirective implements OnInit, OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private ngZone = inject(NgZone);
   private observer?: IntersectionObserver;
+  private activeTween?: any;
 
   ngOnInit(): void {
     if (!isPlatformBrowser(this.platformId)) return;
@@ -46,7 +47,7 @@ export class CountUpDirective implements OnInit, OnDestroy {
             entries.forEach((entry) => {
               if (entry.isIntersecting) {
                 const counter = { val: 0 };
-                gsap.to(counter, {
+                this.activeTween = gsap.to(counter, {
                   val: numericVal,
                   duration: this.duration,
                   ease: 'power2.out',
@@ -74,5 +75,8 @@ export class CountUpDirective implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.observer?.disconnect();
+    if (this.activeTween) {
+      this.activeTween.kill();
+    }
   }
 }

--- a/webiu-ui/src/app/shared/reveal-on-scroll.directive.ts
+++ b/webiu-ui/src/app/shared/reveal-on-scroll.directive.ts
@@ -17,6 +17,7 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
   private platformId = inject(PLATFORM_ID);
   private ngZone = inject(NgZone);
   private observer?: IntersectionObserver;
+  private activeTween?: any;
 
   ngOnInit(): void {
     if (!isPlatformBrowser(this.platformId)) return;
@@ -55,7 +56,7 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
           (entries) => {
             entries.forEach((entry) => {
               if (entry.isIntersecting) {
-                gsap.to(nativeEl, {
+                this.activeTween = gsap.to(nativeEl, {
                   opacity: 1,
                   scale: 1,
                   x: 0,
@@ -85,5 +86,8 @@ export class RevealOnScrollDirective implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.observer?.disconnect();
+    if (this.activeTween) {
+      this.activeTween.kill();
+    }
   }
 }


### PR DESCRIPTION
## Overview
This PR resolves all 4 memory and subscription leak concerns (🔴/🟠) identified in the frontend (`webiu-ui`) code. It replaces manual RxJS subscriptions with native Angular `takeUntilDestroyed` hooks and properly kills active GSAP tweens when animation directives are destroyed.

Fixes #708 

---

## Detailed Changes

### 1. Spotlight Search RxJS Refactor
* **Why:** The component manually instantiated `Subscription` objects and called `.unsubscribe()` in `ngOnDestroy()`.
* **What:** Refactored [spotlight-search.component.ts](file:///Users/tarunyakesh/Desktop/GSOC%2026/WebiU_Dev/webiu-ui/src/app/components/spotlight-search/spotlight-search.component.ts) to inject `DestroyRef` and pipe all input search debouncing streams through `takeUntilDestroyed(this.destroyRef)`. Removed the entire `ngOnDestroy` hook.

### 2. Admin Ideas queryParams Subscription Cleanup
* **Why:** The tabbed query parameters listener in `ngOnInit()` did not clean up when navigating away, causing duplicate subscriptions to accumulate upon successive admin dashboard entries.
* **What:** Refactored [admin-ideas.component.ts](file:///Users/tarunyakesh/Desktop/GSOC%2026/WebiU_Dev/webiu-ui/src/app/page/admin-ideas/admin-ideas.component.ts) to pipe the `route.queryParams` subscription through `takeUntilDestroyed(this.destroyRef)`.

### 3. GSAP Active Tween Cleanups on Reveal Scroll Directive
* **Why:** The directive disconnected the `IntersectionObserver` on destroy but did not stop the running GSAP opacity/translate transitions, causing detached DOM elements to remain in memory.
* **What:** Stored the returned tween reference from `gsap.to()` in [reveal-on-scroll.directive.ts](file:///Users/tarunyakesh/Desktop/GSOC%2026/WebiU_Dev/webiu-ui/src/app/shared/reveal-on-scroll.directive.ts) and terminated it inside `ngOnDestroy()`.

### 4. GSAP Active Tween Cleanups on Count-Up Directive
* **Why:** Similar to reveal-on-scroll, count-up animations destroyed mid-run continued running, leading to memory leaks.
* **What:** Stored the returned tween reference from `gsap.to()` in [count-up.directive.ts](file:///Users/tarunyakesh/Desktop/GSOC%2026/WebiU_Dev/webiu-ui/src/app/shared/count-up.directive.ts) and terminated it inside `ngOnDestroy()`.

---

## Verification & Validation Results

* **Linting & Formatting:** All linters and formatter checks pass with **0 errors**.
* **Builds:** The Angular project compiles and builds successfully.
* **Unit Tests:** All **60/60 frontend unit tests** pass successfully.