### PR TITLE
fix(ui): swap getDelta()/getElapsedTime() order to unfreeze mascot timed animations

### DIFF
--- a/webiu-ui/src/app/components/community-mascot/community-mascot.component.ts
+++ b/webiu-ui/src/app/components/community-mascot/community-mascot.component.ts
@@ -995,8 +995,8 @@ export class CommunityMascotComponent implements AfterViewInit, OnDestroy {
     if (!this.isAnimating || !this.renderer || !this.scene || !this.camera) return;
     this.animationId = requestAnimationFrame(this.animate);
 
-    const elapsed = this.clock.getElapsedTime();
     const deltaTime = Math.min(this.clock.getDelta(), 0.1); // cap delta time to prevent giant frame leaps
+    const elapsed = this.clock.elapsedTime;
 
     // 1. Mouse movements look-at ease interpolation
     this.mouse.x += (this.mouse.targetX - this.mouse.x) * 0.08;


### PR DESCRIPTION
Fixes #714

## Description
community-mascot.component.ts lines 998-999 call clock.getElapsedTime() first, then clock.getDelta() immediately after. Three.js Clock.getElapsedTime() internally calls getDelta(), resetting the internal delta counter. The subsequent getDelta() always returns ~0, freezing all timed animations.

The fix swaps the two lines and uses clock.elapsedTime (a read-only property that does not call getDelta() internally) instead of clock.getElapsedTime() for elapsed time.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] npm run lint — 0 errors
- [X] npm run build — 0 errors
- [X] ng test — 59/59 tests pass

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] My PR description accurately matches the actual code changes and file diffs