### PR TITLE
fix(server): return proper CORS rejection instead of 500 for disallowed origins

### DIFF
--- a/webiu-server/src/main.ts
+++ b/webiu-server/src/main.ts
@@ -70,7 +70,7 @@ async function bootstrap() {
       if (!origin || allowedOrigins.includes(origin.replace(/\/$/, ''))) {
         callback(null, true);
       } else {
-        callback(new Error(`Origin ${origin} not allowed by CORS`));
+        callback(null, false);
       }
     },
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],


### PR DESCRIPTION
## Description

Disallowed CORS origins currently receive a 500 Internal Server Error
with the origin URL leaked in the response body. The CORS origin callback
at `webiu-server/src/main.ts:73` calls `callback(new Error(...))`, which
Express treats as an unhandled error.

**Fix:** Replace with `callback(null, false)`. This tells the cors middleware
to omit the `Access-Control-Allow-Origin` header for disallowed origins,
letting the browser enforce the restriction per the CORS specification.
No 500 error, no origin leak.

**Impact:** Only affects disallowed origins (already blocked). Allowed
origins are untouched. Zero new dependencies. Fully backward compatible.

Fixes #716

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run lint` — passes cleanly
- [x] `npm test` — all 212 tests pass (31 suites)
- [x] Manual curl: disallowed origin no longer gets a 500 response

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My PR description accurately matches the actual code changes and file diffs