### PR TITLE
feat(ui): implement interactive garden footer and full-width card layout

### DIFF
--- a/webiu-ui/src/app/components/footer/footer.component.html
+++ b/webiu-ui/src/app/components/footer/footer.component.html
@@ -1,72 +1,248 @@
 <footer class="app-footer">
-  <div class="footer-container">
-    <!-- Org Info Column -->
-    <div class="footer-column org-info">
-      <picture>
-        <source srcset="assets/c2silogo-dark_no_bg.webp" type="image/webp" />
-        <img
-          src="assets/c2silogo-dark_no_bg.png"
-          alt="C2SI Logo"
-          class="footer-logo"
-          width="87"
-          height="44"
-          loading="lazy"
-        />
-      </picture>
-      <p class="tagline">Open Source Intelligence Platform powering research, discovery, and community.</p>
-      <div class="footer-badges">
-        <span class="footer-badge">
-          <span class="footer-badge-dot"></span>
-          Live Platform
-        </span>
-      </div>
-      <p class="copyright">&copy; {{ currentYear }} C2SI · SCoRe Lab. All rights reserved.</p>
+  <!-- Top Meta & Garden Row -->
+  <div class="footer-meta-top">
+    <div class="meta-item copyright">
+      &copy; {{ currentYear }} C2SI · SCoRe Lab
+    </div>
+    
+    <!-- The Garden (Swaying SVG Flower Clusters) -->
+    <div class="footer-garden">
+      <!-- Cluster 1: Double Daisy -->
+      <svg viewBox="0 0 40 60" class="flower-svg daisy double">
+        <!-- Tall Daisy -->
+        <path d="M15,60 Q15,30 15,18" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M15,45 Q7,42 10,36 Q13,38 15,45" fill="currentColor"/>
+        <circle cx="15" cy="18" r="4.5" fill="currentColor"/>
+        <circle cx="10" cy="18" r="3" fill="currentColor"/>
+        <circle cx="20" cy="18" r="3" fill="currentColor"/>
+        <circle cx="15" cy="13" r="3" fill="currentColor"/>
+        <circle cx="15" cy="23" r="3" fill="currentColor"/>
+        <circle cx="15" cy="18" r="1.5" class="flower-center"/>
+        <!-- Short Daisy -->
+        <path d="M15,60 Q22,45 25,28" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M22,48 Q28,45 25,39 Q21,41 22,48" fill="currentColor"/>
+        <circle cx="25" cy="28" r="4" fill="currentColor"/>
+        <circle cx="21" cy="28" r="2.5" fill="currentColor"/>
+        <circle cx="29" cy="28" r="2.5" fill="currentColor"/>
+        <circle cx="25" cy="24" r="2.5" fill="currentColor"/>
+        <circle cx="25" cy="32" r="2.5" fill="currentColor"/>
+        <circle cx="25" cy="28" r="1.2" class="flower-center"/>
+      </svg>
+      
+      <!-- Cluster 2: Tulip + Daisy -->
+      <svg viewBox="0 0 40 60" class="flower-svg tulip daisy-pair">
+        <!-- Tulip Left -->
+        <path d="M20,60 Q12,40 12,25" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M16,46 Q7,45 11,38 Q14,41 16,46" fill="currentColor"/>
+        <path d="M6,25 C6,31 18,31 18,25 C18,17 16,15 12,20 C8,15 6,17 6,25 Z" fill="currentColor"/>
+        <!-- Daisy Right -->
+        <path d="M20,60 Q24,45 26,34" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M22,48 Q30,48 27,42 Q23,43 22,48" fill="currentColor"/>
+        <circle cx="26" cy="34" r="4" fill="currentColor"/>
+        <circle cx="22" cy="34" r="2.5" fill="currentColor"/>
+        <circle cx="30" cy="34" r="2.5" fill="currentColor"/>
+        <circle cx="26" cy="30" r="2.5" fill="currentColor"/>
+        <circle cx="26" cy="38" r="2.5" fill="currentColor"/>
+        <circle cx="26" cy="34" r="1.2" class="flower-center"/>
+      </svg>
+
+      <!-- Cluster 3: Tall Daisy with leaves/thorns and a small bud -->
+      <svg viewBox="0 0 40 60" class="flower-svg daisy tall-daisy-bud">
+        <!-- Small Bud Right -->
+        <path d="M20,60 Q27,52 32,46" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M32,46 C29,46 29,40 32,37 C35,40 35,46 32,46 Z" fill="currentColor"/>
+        <!-- Tall Daisy -->
+        <path d="M20,60 Q20,30 20,12" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M20,48 Q10,48 14,42 Q17,45 20,48" fill="currentColor"/>
+        <path d="M20,36 Q28,34 25,28 Q21,30 20,36" fill="currentColor"/>
+        <path d="M20,28 Q12,26 15,20 Q18,22 20,28" fill="currentColor"/>
+        <circle cx="20" cy="12" r="5" fill="currentColor"/>
+        <circle cx="14" cy="12" r="3.5" fill="currentColor"/>
+        <circle cx="26" cy="12" r="3.5" fill="currentColor"/>
+        <circle cx="20" cy="6" r="3.5" fill="currentColor"/>
+        <circle cx="20" cy="18" r="3.5" fill="currentColor"/>
+        <circle cx="20" cy="12" r="1.5" class="flower-center"/>
+      </svg>
+
+      <!-- Cluster 4: Triple Daisy -->
+      <svg viewBox="0 0 40 60" class="flower-svg daisy triple">
+        <!-- Tall Center Daisy -->
+        <path d="M20,60 Q20,35 20,20" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <circle cx="20" cy="20" r="4.5" fill="currentColor"/>
+        <circle cx="15" cy="20" r="3" fill="currentColor"/>
+        <circle cx="25" cy="20" r="3" fill="currentColor"/>
+        <circle cx="20" cy="15" r="3" fill="currentColor"/>
+        <circle cx="20" cy="25" r="3" fill="currentColor"/>
+        <circle cx="20" cy="20" r="1.5" class="flower-center"/>
+        <!-- Left Daisy -->
+        <path d="M20,60 Q13,48 10,32" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <circle cx="10" cy="32" r="3.5" fill="currentColor"/>
+        <circle cx="6" cy="32" r="2.2" fill="currentColor"/>
+        <circle cx="14" cy="32" r="2.2" fill="currentColor"/>
+        <circle cx="10" cy="28" r="2.2" fill="currentColor"/>
+        <circle cx="10" cy="36" r="2.2" fill="currentColor"/>
+        <circle cx="10" cy="32" r="1" class="flower-center"/>
+        <!-- Right Daisy -->
+        <path d="M20,60 Q27,48 30,32" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <circle cx="30" cy="32" r="3.5" fill="currentColor"/>
+        <circle cx="26" cy="32" r="2.2" fill="currentColor"/>
+        <circle cx="34" cy="32" r="2.2" fill="currentColor"/>
+        <circle cx="30" cy="28" r="2.2" fill="currentColor"/>
+        <circle cx="30" cy="36" r="2.2" fill="currentColor"/>
+        <circle cx="30" cy="32" r="1" class="flower-center"/>
+      </svg>
+
+      <!-- Cluster 5: Tulip + Bud -->
+      <svg viewBox="0 0 40 60" class="flower-svg tulip single-tulip-bud">
+        <!-- Bud Left -->
+        <path d="M20,60 Q13,54 8,48" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+        <path d="M8,48 C5,48 5,43 8,40 C11,43 11,48 8,48 Z" fill="currentColor"/>
+        <!-- Tulip Center -->
+        <path d="M20,60 Q22,35 22,20" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M21,42 Q28,40 26,34 Q22,36 21,42" fill="currentColor"/>
+        <path d="M21,30 Q14,26 17,20 Q19,23 21,30" fill="currentColor"/>
+        <path d="M16,20 C16,26 28,26 28,20 C28,13 25,11 22,16 C19,11 16,13 16,20 Z" fill="currentColor"/>
+      </svg>
+
+      <!-- Cluster 6: Daisy + Tulip -->
+      <svg viewBox="0 0 40 60" class="flower-svg daisy-tulip-pair">
+        <!-- Daisy Left -->
+        <path d="M20,60 Q15,42 12,24" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M15,44 Q7,40 11,34 Q14,37 15,44" fill="currentColor"/>
+        <circle cx="12" cy="24" r="4.5" fill="currentColor"/>
+        <circle cx="7.5" cy="24" r="3" fill="currentColor"/>
+        <circle cx="16.5" cy="24" r="3" fill="currentColor"/>
+        <circle cx="12" cy="19.5" r="3" fill="currentColor"/>
+        <circle cx="12" cy="28.5" r="3" fill="currentColor"/>
+        <circle cx="12" cy="24" r="1.5" class="flower-center"/>
+        <!-- Tulip Right -->
+        <path d="M20,60 Q25,40 32,23" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M27,42 Q36,44 32,38 Q29,39 27,42" fill="currentColor"/>
+        <path d="M26,23 C26,29 38,29 38,23 C38,15 35,13 32,18 C29,13 26,15 26,23 Z" fill="currentColor"/>
+      </svg>
+
+      <!-- Cluster 7: Daisy + 2 Buds -->
+      <svg viewBox="0 0 40 60" class="flower-svg daisy-buds-pair">
+        <!-- Bud Left Low -->
+        <path d="M20,60 Q13,54 8,48" stroke="currentColor" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+        <path d="M8,48 C5,48 5,43 8,40 C11,43 11,48 8,48 Z" fill="currentColor"/>
+        <!-- Bud Right Mid -->
+        <path d="M20,60 Q26,45 32,36" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M32,36 C29,36 29,30 32,27 C35,30 35,36 32,36 Z" fill="currentColor"/>
+        <!-- Daisy Center -->
+        <path d="M20,60 Q20,32 20,20" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+        <path d="M20,40 Q28,38 25,32 Q21,34 20,40" fill="currentColor"/>
+        <circle cx="20" cy="20" r="4.5" fill="currentColor"/>
+        <circle cx="15.5" cy="20" r="3" fill="currentColor"/>
+        <circle cx="24.5" cy="20" r="3" fill="currentColor"/>
+        <circle cx="20" cy="15.5" r="3" fill="currentColor"/>
+        <circle cx="20" cy="24.5" r="3" fill="currentColor"/>
+        <circle cx="20" cy="20" r="1.5" class="flower-center"/>
+      </svg>
     </div>
 
-    <!-- Navigation Column -->
-    <div class="footer-column">
-      <h3>Explore</h3>
-      <ul>
-        <li><a routerLink="/projects" routerLinkActive="active">Projects</a></li>
-        <li><a routerLink="/contributors" routerLinkActive="active">Contributors</a></li>
-        <li><a routerLink="/publications" routerLinkActive="active">Publications</a></li>
-        <li><a routerLink="/search" routerLinkActive="active">Search</a></li>
-      </ul>
-    </div>
-
-    <!-- Community Column -->
-    <div class="footer-column">
-      <h3>Community</h3>
-      <ul>
-        <li><a routerLink="/community" routerLinkActive="active">Community</a></li>
-        <li><a routerLink="/opportunities" routerLinkActive="active">Opportunities</a></li>
-        <li><a routerLink="/gsoc" routerLinkActive="active">GSoC Hub</a></li>
-      </ul>
-    </div>
-
-    <!-- Connect Column -->
-    <div class="footer-column">
-      <h3>Connect</h3>
-      <ul>
-        <li>
-          <a href="https://github.com/c2siorg" target="_blank" rel="noopener noreferrer">GitHub</a>
-        </li>
-        <li>
-          <a href="https://www.linkedin.com/company/c2siorg/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-        </li>
-        <li>
-          <a href="https://scorelab.org/" target="_blank" rel="noopener noreferrer">SCoRe Lab</a>
-        </li>
-        <li>
-          <a href="mailto:gsoc@c2si.com">Email Us</a>
-        </li>
-      </ul>
+    <div class="meta-item status">
+      <span class="footer-badge-dot"></span> Powered by open source, no plans to stop
     </div>
   </div>
 
-  <!-- Footer Bottom Bar -->
-  <div class="footer-bottom">
-    <p class="footer-bottom-text">Built with Angular · Open Source on <a href="https://github.com/c2siorg/Webiu" target="_blank" rel="noopener noreferrer">GitHub</a></p>
-    <p class="footer-tech">Made with <span>♥</span> by the C2SI community <span class="handwritten" style="font-size: 1.2rem; color: var(--accent-lime); margin-left: 8px; display: inline-block; transform: rotate(-2deg); vertical-align: middle;">Built by contributors.</span></p>
+  <!-- The Main Full-Width Footer Card -->
+  <div class="footer-card">
+    <!-- Huge blended background branding -->
+    <div class="footer-bg-text">Ceylon Computer Sci Int.</div>
+
+    <!-- 3-Column Navigation Grid -->
+    <div class="footer-columns-grid">
+      <!-- Column 1: Explore -->
+      <div class="footer-col">
+        <h3>Explore</h3>
+        <ul>
+          <li>
+            <a routerLink="/projects" routerLinkActive="active">
+              <i class="fas fa-project-diagram"></i> Projects
+            </a>
+          </li>
+          <li>
+            <a routerLink="/contributors" routerLinkActive="active">
+              <i class="fas fa-users"></i> Contributors
+            </a>
+          </li>
+          <li>
+            <a routerLink="/publications" routerLinkActive="active">
+              <i class="fas fa-book"></i> Publications
+            </a>
+          </li>
+          <li>
+            <a routerLink="/search" routerLinkActive="active">
+              <i class="fas fa-search"></i> Search
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Column 2: Community -->
+      <div class="footer-col">
+        <h3>Community</h3>
+        <ul>
+          <li>
+            <a routerLink="/community" routerLinkActive="active">
+              <i class="fas fa-comments"></i> Community
+            </a>
+          </li>
+          <li>
+            <a routerLink="/opportunities" routerLinkActive="active">
+              <i class="fas fa-briefcase"></i> Opportunities
+            </a>
+          </li>
+          <li>
+            <a routerLink="/gsoc" routerLinkActive="active">
+              <i class="fas fa-graduation-cap"></i> GSoC Hub
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Column 3: Connect -->
+      <div class="footer-col">
+        <h3>Connect</h3>
+        <ul>
+          <li>
+            <a href="https://github.com/c2siorg" target="_blank" rel="noopener noreferrer">
+              <i class="fab fa-github"></i> GitHub
+            </a>
+          </li>
+          <li>
+            <a href="https://www.linkedin.com/company/c2siorg/" target="_blank" rel="noopener noreferrer">
+              <i class="fab fa-linkedin"></i> LinkedIn
+            </a>
+          </li>
+          <li>
+            <a href="https://scorelab.org/" target="_blank" rel="noopener noreferrer">
+              <i class="fas fa-globe"></i> SCoRe Lab
+            </a>
+          </li>
+          <li>
+            <a href="mailto:gsoc@c2si.com">
+              <i class="fas fa-envelope"></i> Email Us
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Footer Bottom Details inside Card -->
+    <div class="footer-bottom-row">
+      <div class="bottom-item tech">
+        Built with Angular &middot; Open Source on <a href="https://github.com/c2siorg/Webiu" target="_blank" rel="noopener noreferrer">GitHub</a>
+      </div>
+      <div class="bottom-item credits">
+        Made with <span>♥</span> by the C2SI community
+      </div>
+      <div class="bottom-item actions">
+        <a href="#" (click)="scrollToTop($event)" class="back-to-top-btn">
+          <i class="fas fa-arrow-up"></i> Back to top
+        </a>
+      </div>
+    </div>
   </div>
 </footer>

--- a/webiu-ui/src/app/components/footer/footer.component.scss
+++ b/webiu-ui/src/app/components/footer/footer.component.scss
@@ -1,88 +1,225 @@
 /* ─────────────────────────────────────────────────────────────
    WebiU 2.0 — Footer Component
+   Garden & Glowing Card Theme (Full Viewport Width)
    ───────────────────────────────────────────────────────────── */
 
 .app-footer {
-  background: var(--surface);
-  border-top: 1px solid var(--border);
-  margin-top: auto;
-}
-
-.footer-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 56px clamp(1rem, 5vw, 2rem) 32px;
-  display: grid;
-  grid-template-columns: 1.6fr 1fr 1fr 1fr;
-  gap: 40px;
-  align-items: flex-start;
-}
-
-/* Org info column */
-.org-info {
+  position: relative;
+  background: var(--bg);
+  padding: 60px 0 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
-.footer-logo {
-  height: 44px;
-  width: auto;
-  object-fit: contain;
-}
-
-.tagline {
-  font-size: var(--font-size-sm);
-  color: var(--text-secondary);
-  line-height: 1.7;
-  max-width: 240px;
-}
-
-.footer-badges {
+/* ── Top Meta & Garden Row ── */
+.footer-meta-top {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 clamp(1rem, 5vw, 2.5rem) 12px;
+  position: relative;
 }
 
-.footer-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 10px;
-  border-radius: var(--radius-full);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  background: var(--accent-lime-dim);
-  color: #4a6b00;
-  border: 1px solid rgba(199, 244, 100, 0.3);
+.meta-item {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  opacity: 0.8;
+  padding-bottom: 4px;
 }
 
-[data-theme="dark"] .footer-badge {
-  color: var(--accent-lime);
-}
-
+/* ── Status Pulse Dot ── */
 .footer-badge-dot {
-  width: 6px;
-  height: 6px;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--accent-lime);
-  animation: pulse-badge 2s infinite;
+  position: relative;
+  margin-right: 6px;
+  vertical-align: middle;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    border-radius: 50%;
+    background: var(--accent-lime);
+    animation: ping-dot 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+  }
 }
 
-@keyframes pulse-badge {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.6; transform: scale(0.85); }
+@keyframes ping-dot {
+  75%, 100% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
 }
 
-.copyright {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
-  margin-top: auto;
+/* ── The Garden (Swaying SVG Flower Clusters) ── */
+.footer-garden {
+  display: flex;
+  align-items: flex-end;
+  gap: clamp(8px, 1.8vw, 18px);
+  z-index: 10;
+  pointer-events: auto;
+  position: absolute;
+  bottom: -2px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
-/* Nav columns */
-.footer-column {
+.flower-svg {
+  height: clamp(48px, 5.2vw, 66px);
+  width: auto;
+  color: var(--accent-purple);
+  transform-origin: 50% 100%;
+  transition: color var(--transition), filter var(--transition), transform var(--transition);
+  animation: sway 4.5s ease-in-out infinite alternate;
+
+  /* Custom scaling and animations to mimic original reference heights */
+  &.double {
+    height: clamp(48px, 5.2vw, 64px);
+    animation-delay: -0.4s;
+    animation-duration: 4.2s;
+  }
+  
+  &.daisy-pair {
+    height: clamp(46px, 5.0vw, 62px);
+    animation-delay: -1.2s;
+    animation-duration: 4.8s;
+  }
+
+  &.tall-daisy-bud {
+    height: clamp(56px, 6.0vw, 74px);
+    animation-delay: -2.0s;
+    animation-duration: 3.8s;
+  }
+
+  &.triple {
+    height: clamp(44px, 4.8vw, 60px);
+    animation-delay: -0.7s;
+    animation-duration: 5.2s;
+  }
+
+  &.single-tulip-bud {
+    height: clamp(50px, 5.4vw, 66px);
+    animation-delay: -2.5s;
+    animation-duration: 4.5s;
+  }
+
+  &.daisy-tulip-pair {
+    height: clamp(48px, 5.2vw, 64px);
+    animation-delay: -1.5s;
+    animation-duration: 5.0s;
+  }
+
+  &.daisy-buds-pair {
+    height: clamp(46px, 5.0vw, 62px);
+    animation-delay: -0.9s;
+    animation-duration: 4.0s;
+  }
+
+  /* Center dot of daisy */
+  .flower-center {
+    fill: var(--bg);
+    transition: fill var(--transition);
+  }
+
+  /* Hover interactivity */
+  &:hover {
+    cursor: pointer;
+    color: var(--accent-lime) !important;
+    filter: drop-shadow(0 0 8px var(--accent-lime));
+    transform: scale(1.15);
+    animation: sway-hover 0.5s ease-in-out infinite alternate;
+
+    .flower-center {
+      fill: var(--accent-coral) !important;
+    }
+  }
+}
+
+/* ── The Main Footer Card (Full Width) ── */
+.footer-card {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  border-radius: 24px 24px 0 0;
+  padding: 80px clamp(1rem, 5vw, 2.5rem) 40px;
+  box-sizing: border-box;
+  z-index: 2;
+
+  /* Standard Dark Mode Card Styles using Predefined Variables */
+  border-top: 2px solid var(--accent-purple);
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  background: linear-gradient(180deg, var(--accent-purple-dim) 0%, var(--surface) 50%, var(--bg) 100%);
+  box-shadow: 0 -12px 40px -15px var(--accent-purple-dim);
+}
+
+/* Light Theme Overrides */
+:host-context([data-theme="light"]) {
+  .footer-card {
+    border-top: 2px solid var(--accent-purple);
+    background: linear-gradient(180deg, var(--accent-purple-dim) 0%, var(--surface-raised) 50%, var(--surface) 100%);
+    box-shadow: 0 -10px 30px -18px var(--accent-purple-dim);
+  }
+
+  .footer-bg-text {
+    color: var(--text-primary);
+    opacity: 0.02;
+  }
+
+  .flower-svg {
+    .flower-center {
+      fill: #FFFFFF;
+    }
+  }
+}
+
+/* ── Huge Blended Background Branding ── */
+.footer-bg-text {
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: 'Clash Display', 'Geist', system-ui, sans-serif;
+  font-size: clamp(2.5rem, 7.8vw, 7.2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  opacity: 0.02;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 1;
+  text-align: center;
+  user-select: none;
+}
+
+/* ── Centered Columns Grid ── */
+.footer-columns-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 48px;
+  margin-bottom: 56px;
+  position: relative;
+  z-index: 3;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.footer-col {
   h3 {
     font-family: 'Geist', system-ui, sans-serif;
     font-size: var(--font-size-xs);
@@ -90,27 +227,40 @@
     color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    margin-bottom: 16px;
+    margin-bottom: 20px;
   }
 
   ul {
     list-style: none;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
 
     li a {
+      font-family: 'Geist', system-ui, sans-serif;
       font-size: var(--font-size-sm);
       color: var(--text-secondary);
       text-decoration: none;
-      transition: color var(--transition-fast);
-      display: flex;
+      transition: all var(--transition-fast);
+      display: inline-flex;
       align-items: center;
-      gap: 6px;
+      gap: 8px;
+
+      i {
+        font-size: 14px;
+        color: var(--text-muted);
+        transition: color var(--transition-fast), transform var(--transition-fast);
+      }
 
       &:hover {
         color: var(--accent-purple);
+        transform: translateX(4px);
         opacity: 1;
+
+        i {
+          color: var(--accent-lime);
+          transform: scale(1.1);
+        }
       }
 
       &.active {
@@ -121,78 +271,113 @@
   }
 }
 
-/* Footer bottom bar */
-.footer-bottom {
-  border-top: 1px solid var(--border);
-  padding: 16px clamp(1rem, 5vw, 2rem);
-  max-width: 1200px;
-  margin: 0 auto;
+/* ── Bottom Row Details inside Card ── */
+.footer-bottom-row {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+  align-items: center;
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  position: relative;
+  z-index: 3;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.footer-bottom-text {
-  font-size: var(--font-size-xs);
+.bottom-item {
+  font-size: 12px;
   color: var(--text-muted);
-}
-
-.footer-tech {
-  font-size: var(--font-size-xs);
-  color: var(--text-muted);
-
-  span {
-    color: var(--accent-coral);
-    margin: 0 2px;
-  }
 
   a {
     color: var(--text-muted);
     text-decoration: none;
-    &:hover { color: var(--accent-purple); opacity: 1; }
+    transition: color var(--transition-fast);
+    font-weight: 500;
+
+    &:hover {
+      color: var(--accent-purple);
+      opacity: 1;
+    }
+  }
+
+  span {
+    color: var(--accent-coral);
+    animation: heartbeat 1.6s infinite ease-in-out;
+    display: inline-block;
   }
 }
 
-/* Responsive */
+.back-to-top-btn {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: all var(--transition-fast);
+
+  i {
+    transition: transform var(--transition-fast);
+  }
+
+  &:hover {
+    color: var(--accent-coral);
+    opacity: 1;
+
+    i {
+      transform: translateY(-3px);
+    }
+  }
+}
+
+/* ── Keyframes ── */
+@keyframes sway {
+  0% { transform: rotate(-5.5deg) scaleY(0.96); }
+  100% { transform: rotate(5.5deg) scaleY(1.02); }
+}
+
+@keyframes sway-hover {
+  0% { transform: rotate(-12deg) scale(1.15); }
+  100% { transform: rotate(12deg) scale(1.15); }
+}
+
+@keyframes heartbeat {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.22); }
+}
+
+/* ── Responsive Styling ── */
 @media (max-width: 960px) {
-  .footer-container {
-    grid-template-columns: 1fr 1fr;
+  .footer-meta-top {
+    justify-content: center;
+  }
+
+  .meta-item {
+    display: none; /* Hide side texts to focus layout on flowers */
+  }
+
+  .footer-columns-grid {
+    gap: 28px;
+    padding: 0 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .footer-card {
+    padding: 60px 20px 24px;
+  }
+
+  .footer-columns-grid {
+    grid-template-columns: 1fr;
     gap: 32px;
   }
 
-  .org-info {
-    grid-column: 1 / -1;
-  }
-}
-
-@media (max-width: 600px) {
-  .footer-container {
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    padding-top: 40px;
-    padding-bottom: 24px;
-  }
-
-  .org-info {
-    grid-column: 1 / -1;
-  }
-
-  .footer-bottom {
+  .footer-bottom-row {
     flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-  }
-}
-
-/* Dark theme overrides */
-:host-context([data-theme="dark"]) {
-  .app-footer {
-    background: var(--surface);
-    border-top-color: var(--border);
-  }
-  .footer-logo {
-    filter: invert(1);
+    gap: 12px;
+    text-align: center;
   }
 }

--- a/webiu-ui/src/app/components/footer/footer.component.ts
+++ b/webiu-ui/src/app/components/footer/footer.component.ts
@@ -12,4 +12,12 @@ import { RouterModule } from '@angular/router';
 })
 export class FooterComponent {
   currentYear = new Date().getFullYear();
+
+  scrollToTop(event: Event): void {
+    event.preventDefault();
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
 }


### PR DESCRIPTION
### Overview
Redesigns the website footer to feature a full-width glowing card layout and interactive garden elements.

Closes #720 

### Changes
- **Layout:** Stretched the footer card to `100%` viewport width, aligned flush at the page bottom with a `24px` top border radius.
- **Garden Elements:** Placed 7 multi-stem swaying SVG flower clusters (Daisies, Tulips, Buds) on the top border edge.
- **Interactivity:** Flowers sway organically at varying cycles and wiggle/glow green on hover. Added a pulsing live status indicator.
- **Navigation:** Restored all original columns (`Explore`, `Community`, and `Connect`) in a responsive grid. Added a smooth scroll-to-top handler.
- **Branding:** Placed a watermark background reading "Ceylon Computer Sci Int." behind the grid.
- **Theme Variables:** Styled strictly with existing CSS tokens (`var(--surface)`, `var(--bg)`, `var(--accent-purple-dim)`) with no hardcoded colors.


https://github.com/user-attachments/assets/3d175612-47ec-41d1-9046-3f3023fda3a0

