### PR TITLE
fix(server): add @Throttle decorator to ProjectController

### DIFF
--- a/webiu-server/src/project/project.controller.ts
+++ b/webiu-server/src/project/project.controller.ts
@@ -7,11 +7,13 @@ import {
   Param,
   UseGuards,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ProjectService } from './project.service';
 import { RepositorySyncService } from './repository-sync.service';
 import { AdminGuard } from '../auth/guards/admin.guard';
 
 @Controller('api/v1/projects')
+@Throttle({ default: { ttl: 60000, limit: 20 } })
 export class ProjectController {
   constructor(
     private projectService: ProjectService,


### PR DESCRIPTION
## Description

Adds missing `@Throttle` class-level decorator to `ProjectController` with limit 20 req/min. The sibling `ContributorController` already has this at `contributor.controller.ts:7-8` — `ProjectController` was the one controller that missed it.

Without this, any client can hit `/api/v1/projects/*` unlimited times per minute (only the global 30 req/min guard applies), potentially exhausting GitHub API rate limits since every project endpoint proxies to `api.github.com`.

No new dependencies — `@nestjs/throttler@^6.5.0` already in `package.json`.

Fixes #723

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran the full backend test suite from `webiu-server/`:

- [x] `npm run lint` — ESLint: No issues found
- [x] `npm test` — 31 suites, 212 tests: all passed
- [x] `npm run build` — `nest build` completed successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes