### PR TITLE
fix(server): add Cache-Control headers to UserController GET endpoints

### DIFF
--- a/webiu-server/src/user/user.controller.ts
+++ b/webiu-server/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+import { Controller, Get, Post, Param, Body, Header } from '@nestjs/common';
 import { UserService } from './user.service';
 import { BatchSocialDto } from './dto/batch-social.dto';
 import { UsernameDto } from '../common/dto/username.dto';
@@ -8,6 +8,7 @@ export class UserController {
   constructor(private userService: UserService) {}
 
   @Get('followersAndFollowing/:username')
+  @Header('Cache-Control', 'public, max-age=300')
   async getFollowersAndFollowing(@Param() params: UsernameDto) {
     return this.userService.getFollowersAndFollowing(params.username);
   }
@@ -18,6 +19,7 @@ export class UserController {
   }
 
   @Get('profile/:username')
+  @Header('Cache-Control', 'public, max-age=300')
   async getUserProfile(@Param() params: UsernameDto) {
     return this.userService.getUserProfile(params.username);
   }


### PR DESCRIPTION
## Description

Adds `@Header('Cache-Control', 'public, max-age=300')` to the 2 GET endpoints in `UserController` (`getFollowersAndFollowing` and `getUserProfile`). The POST `batch-social` endpoint is intentionally excluded — browsers don't cache POST responses.

Both sibling controllers (`ContributorController` and `ProjectController`) already have Cache-Control on every GET — `UserController` was the one that missed it.

Without this, every user-profile request bypasses browser cache and hits GitHub API directly.

Fixes #726

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran the full backend test suite from `webiu-server/`:

- [x] `npm run lint` — ESLint: No issues found
- [x] `npm test` — 31 suites, 212 tests: all passed
- [x] `npm run build` — `nest build` completed successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes