### PR TITLE
fix(server): wrap raw error re-throw in DashboardService with InternalServerErrorException

### DIFF
--- a/webiu-server/src/dashboard/dashboard.service.ts
+++ b/webiu-server/src/dashboard/dashboard.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository as TypeOrmRepository } from 'typeorm';
 import { Repository as RepositoryEntity } from '../database/entities/repository.entity';
@@ -128,7 +132,9 @@ export class DashboardService {
       };
     } catch (error) {
       this.logger.error('Error compiling dashboard summary:', error.message);
-      throw error;
+      throw new InternalServerErrorException(
+        'Failed to compile dashboard summary',
+      );
     }
   }
 }


### PR DESCRIPTION
## Description

Replaces the raw `throw error;` in `DashboardService.getDashboardSummary` with `throw new InternalServerErrorException(...)`. The raw re-throw bypasses NestJS's exception layer — the caller gets an unstructured error with no guaranteed HTTP status mapping.

This aligns `DashboardService` with the gold standard pattern used in `ContributorService` (see `contributor.service.ts:60-64`), where all catch blocks wrap errors in `InternalServerErrorException` for consistent response shape and proper HTTP status codes.

No new dependencies — `InternalServerErrorException` is exported from `@nestjs/common`.

Fixes #728 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran the full backend test suite from `webiu-server/`:

- [x] `npm run lint` — ESLint: No issues found
- [x] `npm test` — all tests pass
- [x] `npm run build` — `nest build` completed successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My PR description accurately matches the actual code changes and file diffs